### PR TITLE
Remove duplicate copy task

### DIFF
--- a/scripts/build-electron-dev.js
+++ b/scripts/build-electron-dev.js
@@ -1,14 +1,8 @@
 const fs = require('fs-extra');
 const paths = require('../config/paths');
 
-const mainSrc = paths.appPublic;
-
 function copySrc() {
   fs.emptyDirSync(paths.electronDev);
-
-  fs.copySync(mainSrc, paths.electronDev, {
-    filter: file => !(/__tests__/).test(file),
-  });
 
   fs.copySync(paths.appPublic, paths.electronDev, {
     dereference: true,


### PR DESCRIPTION
This is a minor update to the electron:dev build script, which just popped into my head.

When I adapted the electron-dev script from server, I left in an extra copy step that isn't needed; public is already copied. (Server has its main JS outside the webpack bundle, so it uses the 'mainSrc' copy step.)