### PR TITLE
Hardcode error-overlay CSP hash

### DIFF
--- a/config/inlineCSP.js
+++ b/config/inlineCSP.js
@@ -38,7 +38,7 @@ function hash256(libName) {
   const newline = /\n|\r\n|\r/g;
   const matches = source.split(newline).filter(line => line.match(/^module\.exports.*/));
 
-  if (!matches) {
+  if (!matches || !matches.length) {
     console.warn('No exports matched');
     return null;
   }
@@ -48,12 +48,7 @@ function hash256(libName) {
   vm.createContext(sandbox);
   vm.runInContext(exportedSrc, sandbox);
 
-  // Newer versions of plugin contain source directly; older versions export a string
-  // TODO: remove legacy parsing above once we're sure it's unneeded
-  const clientSource = sandbox.module.exports || source;
-
-  // const cspHash = crypto.createHash('sha256').update(sandbox.module.exports).digest('base64');
-  const cspHash = crypto.createHash('sha256').update(clientSource).digest('base64');
+  const cspHash = crypto.createHash('sha256').update(sandbox.module.exports).digest('base64');
   return cspHash;
 }
 

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -96,13 +96,13 @@ const config = {
     // "REACT_APP_" is a recognized prefix (see config/env.js)
     new InterpolateHtmlPlugin({
       ...env.raw,
-      // Whitelist inlined content for the Content-Security-Policy header
+      // Whitelist inlined content in Content Security Policy
       // REACT_APP_SCRIPT_SRC_CSP: `'sha256-${inlineCSP.hash256('react-error-overlay')}'`,
       // Previously we whitelisted the react-error-overlay using the above code to
       // generate an explicit hash. In the latest version of these tools multiple levels
-      // of indirection make getting at the code to hash very brittle, and as a result
-      // we're now using unsafe-inline at the expense of lack of parity with production.
-      REACT_APP_SCRIPT_SRC_CSP: "'unsafe-inline'",
+      // of indirection make getting at the code to hash very brittle.
+      // For now, hardcode to current version (react-error-overlay@5.0.0-next.3e165448)
+      REACT_APP_SCRIPT_SRC_CSP: "'sha256-gDC0EVcPe9MimCS3ZP14teSHr0GtEx+ggc0VQBfyvRI='",
       // Whitelist inlined content for the Content-Security-Policy header
       REACT_APP_CONNECT_SRC_CSP: 'ws://localhost:* wss://localhost:*',
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -14627,8 +14627,7 @@
         "react-error-overlay": {
             "version": "5.0.0-next.3e165448",
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.0.0-next.3e165448.tgz",
-            "integrity": "sha512-YEDoDZkZWU1+8F1ZvczRYjrMiIQKHqeEwrBcNFIcMWnFMkYT6r7gIH8oBX/mwQlvsCv7kUwbeuN68xal2b7mQw==",
-            "dev": true
+            "integrity": "sha512-YEDoDZkZWU1+8F1ZvczRYjrMiIQKHqeEwrBcNFIcMWnFMkYT6r7gIH8oBX/mwQlvsCv7kUwbeuN68xal2b7mQw=="
         },
         "react-fastclick": {
             "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
         "whatwg-fetch": "2.0.3"
     },
     "dependencies": {
+        "react-error-overlay": "^5.0.0-next.3e165448",
         "thread-loader": "^1.1.5"
     },
     "homepage": ".",


### PR DESCRIPTION
I've left the CSP script in; hopefully we can revert to that in the future.

To test, add an error (e.g., `throw('fake')` inside App.render) and load the app.