### PR TITLE
Feature/form editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11899,6 +11899,24 @@
                 "prepend-http": "1.0.4",
                 "query-string": "4.3.4",
                 "sort-keys": "1.1.2"
+            },
+            "dependencies": {
+                "query-string": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+                    "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "strict-uri-encode": "1.1.0"
+                    }
+                },
+                "strict-uri-encode": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+                    "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+                    "dev": true
+                }
             }
         },
         "npm-run-path": {
@@ -14246,13 +14264,13 @@
             "dev": true
         },
         "query-string": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.1.0.tgz",
+            "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "decode-uri-component": "0.2.0",
+                "strict-uri-encode": "2.0.0"
             }
         },
         "querystring": {
@@ -17994,9 +18012,9 @@
             "dev": true
         },
         "strict-uri-encode": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
             "dev": true
         },
         "string-length": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "postcss-loader": "^2.1.6",
         "promise": "7.1.1",
         "prop-types": "^15.6.2",
+        "query-string": "^6.1.0",
         "react": "^16.4.1",
         "react-color": "^2.14.1",
         "react-dev-utils": "^6.0.0-next.3e165448",

--- a/src/behaviours/Tweened/store.js
+++ b/src/behaviours/Tweened/store.js
@@ -28,6 +28,7 @@ const reducer = (state = intitalState, action) => {
           ...state[action.name],
           [action.element]: {
             node: action.node,
+            bounds: action.bounds,
           },
         },
       };

--- a/src/behaviours/Tweened/tween.js
+++ b/src/behaviours/Tweened/tween.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import { has, get, defer } from 'lodash';
+import { has, get } from 'lodash';
 import anime from 'animejs';
 import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 import store from './store';
@@ -102,14 +102,13 @@ const captureStartAndDefer = (options) => {
 
   const fromBounds = {
     ...defaultRect,
-    ...getAbsoluteBoundingRect(fromTarget.node),
+    ...fromTarget.bounds,
   };
 
   const clone = fromTarget.node.cloneNode(true);
 
-  defer(() => tween(options, { clone, fromBounds }));
+  tween(options, { clone, fromBounds });
 };
 
-// defer waits until next callstack, this is to allow for time for react elements to exist for
-// tweening, with r16 async rendering, this may break.
+
 export default captureStartAndDefer;

--- a/src/behaviours/Zoom.js
+++ b/src/behaviours/Zoom.js
@@ -103,4 +103,10 @@ const Zoom = WrappedComponent =>
     }
   )
 
+
+export const Zoomer = ({ children, ...rest }) => {
+  const Zoomable = Zoom((props) => children(props));
+  return <Zoomable {...rest} />;
+};
+
 export default Zoom;

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Transition } from 'react-transition-group';
@@ -43,6 +44,14 @@ class Card extends PureComponent {
     exitDelay: 0,
   }
 
+  constructor(props) {
+    super(props);
+
+    this.portal = document.createElement('div');
+    const body = document.getElementsByTagName('body')[0];
+    body.appendChild(this.portal);
+  }
+
   get anyButtons() { return this.props.buttons.length > 0; }
 
   render() {
@@ -55,10 +64,11 @@ class Card extends PureComponent {
       exitDuration,
       exitDelay,
     } = this.props;
+
     const classes = cx('card', `card--${this.props.type}`);
     const timeout = enterDuration + enterDelay + exitDuration + exitDelay;
 
-    return (
+    return ReactDOM.createPortal(
       <Transition
         timeout={timeout}
         unmountOnExit
@@ -105,7 +115,8 @@ class Card extends PureComponent {
             </ControlBar>
           </div>
         )}
-      </Transition>
+      </Transition>,
+      this.portal,
     );
   }
 }

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -24,26 +24,43 @@ class Card extends PureComponent {
     buttons: PropTypes.arrayOf(PropTypes.node),
     type: PropTypes.string,
     show: PropTypes.bool,
-    cancel: PropTypes.bool,
+    style: PropTypes.oneOf(['fade', 'wipe']),
+    enterDuration: PropTypes.number,
+    enterDelay: PropTypes.number,
+    exitDuration: PropTypes.number,
+    exitDelay: PropTypes.number,
   };
 
   static defaultProps = {
     type: 'default',
     children: null,
     buttons: [],
-    cancel: false,
     show: false,
+    style: 'wipe',
+    enterDuration: 200,
+    enterDelay: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+    exitDuration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+    exitDelay: 0,
   }
 
   get anyButtons() { return this.props.buttons.length > 0; }
 
   render() {
-    const { buttons, cancel, show } = this.props;
+    const {
+      buttons,
+      show,
+      style,
+      enterDuration,
+      enterDelay,
+      exitDuration,
+      exitDelay,
+    } = this.props;
     const classes = cx('card', `card--${this.props.type}`);
+    const timeout = enterDuration + enterDelay + exitDuration + exitDelay;
 
     return (
       <Transition
-        timeout={getCSSVariableAsNumber('--animation-duration-standard-ms') * 2}
+        timeout={timeout}
         unmountOnExit
         mountOnEnter
         appear
@@ -53,8 +70,8 @@ class Card extends PureComponent {
               targets: el,
               elasticity: 0,
               easing: 'easeInOutQuad',
-              duration: 1,
-              delay: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+              duration: enterDuration,
+              delay: enterDelay,
               ...fadeIn,
             });
           }
@@ -65,8 +82,9 @@ class Card extends PureComponent {
               targets: el,
               elasticity: 0,
               easing: 'easeInOutQuad',
-              duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-              ...(cancel ? wipeOut : fadeOut),
+              duration: exitDuration,
+              delay: exitDelay,
+              ...(style === 'wipe' ? wipeOut : fadeOut),
             });
           }
         }

--- a/src/components/Cards/EditForm.js
+++ b/src/components/Cards/EditForm.js
@@ -10,6 +10,8 @@ import Card from './ProtocolCard';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as formActions } from '../../ducks/modules/protocol/forms';
 
+const formNameFromTitle = title => title.replace(/\W/g, '');
+
 class EditForm extends PureComponent {
   static propTypes = {
     formName: PropTypes.string,
@@ -35,10 +37,10 @@ class EditForm extends PureComponent {
     if (this.props.formName) {
       this.props.updateForm(this.props.formName, form);
     } else {
-      this.props.createForm(form);
+      this.props.createForm(formNameFromTitle(form.title), form);
     }
 
-    this.props.onComplete(form);
+    this.props.onComplete(this.props.formName || formNameFromTitle(form.title), form);
   }
 
   submitForm = () => {

--- a/src/components/Cards/EditForm.js
+++ b/src/components/Cards/EditForm.js
@@ -38,7 +38,7 @@ class EditForm extends PureComponent {
       this.props.createForm(form);
     }
 
-    this.props.onComplete();
+    this.props.onComplete(form);
   }
 
   submitForm = () => {

--- a/src/components/Cards/EditForm.js
+++ b/src/components/Cards/EditForm.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import { submit, isDirty, isInvalid } from 'redux-form';
 import { get } from 'lodash';
 import { Button } from '../../ui/components';
-import FormEditor from '../FormEditor';
+import FormEditor, { formName } from '../FormEditor';
 import Card from './ProtocolCard';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as formActions } from '../../ducks/modules/protocol/forms';
@@ -42,7 +42,7 @@ class EditForm extends PureComponent {
   }
 
   submitForm = () => {
-    this.props.submitForm('edit-form');
+    this.props.submitForm(formName);
   }
 
   renderButtons() {
@@ -83,17 +83,16 @@ class EditForm extends PureComponent {
   }
 }
 
-const editFormIsDirty = isDirty('edit-form');
-const editFormIsInvalid = isInvalid('edit-form');
+const editFormIsDirty = isDirty(formName);
+const editFormIsInvalid = isInvalid(formName);
 
 function mapStateToProps(state, props) {
   const protocol = getProtocol(state);
-  const formName = get(props.match, 'params.form', null);
   const form = get(protocol, ['forms', formName], {});
 
   return {
     form,
-    formName,
+    formName: get(props.match, 'params.form', null),
     hasUnsavedChanges: !formName || editFormIsDirty(state),
     hasErrors: editFormIsInvalid(state),
   };

--- a/src/components/Cards/EditForm.js
+++ b/src/components/Cards/EditForm.js
@@ -10,7 +10,7 @@ import Card from './ProtocolCard';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as formActions } from '../../ducks/modules/protocol/forms';
 
-class Form extends PureComponent {
+class EditForm extends PureComponent {
   static propTypes = {
     formName: PropTypes.string,
     form: PropTypes.object,
@@ -89,7 +89,7 @@ const editFormIsInvalid = isInvalid('edit-form');
 function mapStateToProps(state, props) {
   const protocol = getProtocol(state);
   const formName = get(props.match, 'params.form', null);
-  const form = get(protocol, ['forms', formName], { optionToAddAnother: false });
+  const form = get(protocol, ['forms', formName], {});
 
   return {
     form,
@@ -105,6 +105,6 @@ const mapDispatchToProps = dispatch => ({
   createForm: bindActionCreators(formActions.createForm, dispatch),
 });
 
-export { Form };
+export { EditForm };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Form);
+export default connect(mapStateToProps, mapDispatchToProps)(EditForm);

--- a/src/components/Cards/EditForm.js
+++ b/src/components/Cards/EditForm.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import { submit, isDirty, isInvalid } from 'redux-form';
 import { get } from 'lodash';
 import { Button } from '../../ui/components';
-import FormEditor, { formName } from '../FormEditor';
+import FormEditor, { formName as reduxFormName } from '../FormEditor';
 import Card from './ProtocolCard';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as formActions } from '../../ducks/modules/protocol/forms';
@@ -42,7 +42,7 @@ class EditForm extends PureComponent {
   }
 
   submitForm = () => {
-    this.props.submitForm(formName);
+    this.props.submitForm(reduxFormName);
   }
 
   renderButtons() {
@@ -83,16 +83,17 @@ class EditForm extends PureComponent {
   }
 }
 
-const editFormIsDirty = isDirty(formName);
-const editFormIsInvalid = isInvalid(formName);
+const editFormIsDirty = isDirty(reduxFormName);
+const editFormIsInvalid = isInvalid(reduxFormName);
 
 function mapStateToProps(state, props) {
   const protocol = getProtocol(state);
-  const form = get(protocol, ['forms', formName], {});
+  const formName = get(props.match, 'params.form', null);
+  const form = get(protocol, ['forms', formName], { optionToAddAnother: false });
 
   return {
     form,
-    formName: get(props.match, 'params.form', null),
+    formName,
     hasUnsavedChanges: !formName || editFormIsDirty(state),
     hasErrors: editFormIsInvalid(state),
   };

--- a/src/components/Cards/EditStage.js
+++ b/src/components/Cards/EditStage.js
@@ -7,7 +7,7 @@ import {
   isDirty as isFormDirty,
   isInvalid as isFormInvalid,
 } from 'redux-form';
-import { pick, has } from 'lodash';
+import { has } from 'lodash';
 import { makeGetStage } from '../../selectors/protocol';
 import { Button } from '../../ui/components';
 import Card from './ProtocolCard';
@@ -18,11 +18,11 @@ class EditStage extends PureComponent {
   static propTypes = {
     dirty: PropTypes.bool.isRequired,
     invalid: PropTypes.bool.isRequired,
+    show: PropTypes.bool.isRequired,
     continue: PropTypes.func.isRequired,
     onComplete: PropTypes.func.isRequired,
     stage: PropTypes.object.isRequired,
     stageId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    type: PropTypes.string,
     insertAtIndex: PropTypes.number,
     updateStage: PropTypes.func.isRequired,
     createStage: PropTypes.func.isRequired,
@@ -31,7 +31,6 @@ class EditStage extends PureComponent {
   static defaultProps = {
     stageId: null,
     insertAtIndex: null,
-    type: null,
   };
 
   onUpdate = (stage) => {
@@ -57,12 +56,13 @@ class EditStage extends PureComponent {
   }
 
   render() {
-    const { stage } = this.props;
+    const { stage, show } = this.props;
 
     return (
       <Card
         buttons={this.renderButtons()}
-        {...pick(this.props, ['show', 'className', 'onCancel'])}
+        show={show}
+        onCancel={this.props.onComplete}
       >
         <StageEditor
           stage={stage}

--- a/src/components/Cards/EditStage.js
+++ b/src/components/Cards/EditStage.js
@@ -82,6 +82,7 @@ const mapStateToProps = (state, props) => {
 
   return ({
     stage,
+    stageId,
     insertAtIndex: get(query, 'insertAtIndex'),
     dirty: isFormDirty('edit-stage')(state),
     invalid: isFormInvalid('edit-stage')(state),

--- a/src/components/Cards/ProtocolCard.js
+++ b/src/components/Cards/ProtocolCard.js
@@ -52,7 +52,7 @@ class ProtocolCard extends PureComponent {
       <Card
         {...rest}
         buttons={this.renderButtons()}
-        cancel={cancel}
+        style={cancel ? 'wipe' : 'fade'}
       >
         { this.props.children }
       </Card>

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -48,6 +48,7 @@ Type.propTypes = {
  */
 class VariableRegistry extends Component {
   handleDelete = (category, type) => {
+    // eslint-disable-next-line no-alert
     if (confirm(`Are you sure you want to delete "${type}:${category}"?`)) {
       this.props.deleteType(category, type);
     }

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -48,7 +48,9 @@ Type.propTypes = {
  */
 class VariableRegistry extends Component {
   handleDelete = (category, type) => {
-    this.props.deleteType(category, type);
+    if (confirm(`Are you sure you want to delete "${type}:${category}"?`)) {
+      this.props.deleteType(category, type);
+    }
   };
 
   renderNode = (node, key) => {

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -108,8 +108,6 @@ class VariableRegistry extends Component {
       protocolPath,
     } = this.props;
 
-    if (!protocolPath) { return null; }
-
     return (
       <Card
         show={show}
@@ -125,14 +123,16 @@ class VariableRegistry extends Component {
                 <div className="editor__subsection">
                   {this.renderNodes()}
                 </div>
-                <div className="editor__subsection">
-                  <Link
-                    to={`${protocolPath}/registry/node/`}
-                    className="button button--small"
-                  >
-                    Create new Node type
-                  </Link>
-                </div>
+                { protocolPath &&
+                  <div className="editor__subsection">
+                    <Link
+                      to={`${protocolPath}/registry/node/`}
+                      className="button button--small"
+                    >
+                      Create new Node type
+                    </Link>
+                  </div>
+                }
               </div>
             </Guidance>
 
@@ -143,12 +143,14 @@ class VariableRegistry extends Component {
                   {this.renderEdges()}
                 </div>
                 <div className="editor__subsection">
-                  <Link
-                    to={`${protocolPath}/registry/edge/`}
-                    className="button button--small"
-                  >
-                    Create new Edge type
-                  </Link>
+                  { protocolPath &&
+                    <Link
+                      to={`${protocolPath}/registry/edge/`}
+                      className="button button--small"
+                    >
+                      Create new Edge type
+                    </Link>
+                  }
                 </div>
               </div>
             </Guidance>

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -4,65 +4,95 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { map, has, get } from 'lodash';
+import Color from 'color';
 import { TransitionGroup } from 'react-transition-group';
 import { Wipe } from '../Transitions';
+import { Zoomer } from '../../behaviours/Zoom';
 import { Node, Icon, Button } from '../../ui/components';
 import { Guided } from '../Guided';
 import Guidance from '../Guidance';
 import Card from '../Card';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as variableRegistryActions } from '../../ducks/modules/protocol/variableRegistry';
+import { getCSSVariableAsString } from '../../utils/CSSVariables';
 
 class VariableRegistry extends Component {
   handleDelete = (category, type) => {
     this.props.deleteType(category, type);
   };
 
-  renderNode = (node, key) => (
-    <Wipe key={key}>
-      <div className="list__item" key={key}>
-        <div className="list__attribute list__attribute--icon">
-          <Link to={`${this.props.protocolPath}/registry/node/${key}`}>
-            <Node label="" color={get(node, 'color', '')} />
-          </Link>
+  renderNode = (node, key) => {
+    const nodeColor = get(node, 'color', '');
+    const nodeColorHex = Color(getCSSVariableAsString(`--${nodeColor}`)).hex();
+    const nodeZoomColors = [nodeColorHex, '#fff'];
+    return (
+      <Wipe key={key}>
+        <div className="list__item" key={key}>
+          <div className="list__attribute list__attribute--icon">
+            <Zoomer zoomColors={nodeZoomColors}>
+              {() => (
+                <Link to={`${this.props.protocolPath}/registry/node/${key}`}>
+                  <Node label="" color={get(node, 'color', '')} />
+                </Link>
+              )}
+            </Zoomer>
+          </div>
+          <div className="list__attribute">
+            <Zoomer zoomColors={nodeZoomColors}>
+              {() => (
+                <h3>
+                  <Link to={`${this.props.protocolPath}/registry/node/${key}`}>
+                    {key}
+                  </Link>
+                </h3>
+              )}
+            </Zoomer>
+          </div>
+          <div className="list__attribute list__attribute--options">
+            <Button size="small" color="neon-coral" onClick={() => this.handleDelete('node', key)}>
+              Delete
+            </Button>
+          </div>
         </div>
-        <div className="list__attribute">
-          <h3>
-            <Link to={`${this.props.protocolPath}/registry/node/${key}`}>
-              {key}
-            </Link>
-          </h3>
-        </div>
-        <div className="list__attribute list__attribute--options">
-          <Button size="small" color="neon-coral" onClick={() => this.handleDelete('node', key)}>
-            Delete
-          </Button>
-        </div>
-      </div>
-    </Wipe>
-  );
+      </Wipe>
+    );
+  }
 
-  renderEdge = (edge, key) => (
-    <Wipe key={key}>
-      <div className="list__item" key={key}>
-        <div className="list__attribute list__attribute--icon">
-          <Link to={`${this.props.protocolPath}/registry/edge/${key}`}>
-            <Icon name="links" color={get(edge, 'color', '').replace('color-', '')} />
-          </Link>
+  renderEdge = (edge, key) => {
+    const edgeColor = get(edge, 'color', '');
+    const edgeColorHex = Color(getCSSVariableAsString(`--color-${edgeColor}`)).hex();
+    const edgeZoomColors = [edgeColorHex, '#fff'];
+
+    return (
+      <Wipe key={key}>
+        <div className="list__item" key={key}>
+          <div className="list__attribute list__attribute--icon">
+            <Zoomer zoomColors={edgeZoomColors}>
+              {() => (
+                <Link to={`${this.props.protocolPath}/registry/edge/${key}`}>
+                  <Icon name="links" color={get(edge, 'color', '')} />
+                </Link>
+              )}
+            </Zoomer>
+          </div>
+          <div className="list__attribute">
+            <Zoomer zoomColors={edgeZoomColors}>
+              {() => (
+                <h3>
+                  <Link to={`${this.props.protocolPath}/registry/edge/${key}`}>
+                    {key}
+                  </Link>
+                </h3>
+              )}
+            </Zoomer>
+          </div>
+          <div className="list__attribute list__attribute--options">
+            <Button size="small" color="neon-coral" onClick={() => this.handleDelete('edge', key)}>Delete</Button>
+          </div>
         </div>
-        <div className="list__attribute">
-          <h3>
-            <Link to={`${this.props.protocolPath}/registry/edge/${key}`}>
-              {key}
-            </Link>
-          </h3>
-        </div>
-        <div className="list__attribute list__attribute--options">
-          <Button size="small" color="neon-coral" onClick={() => this.handleDelete('edge', key)}>Delete</Button>
-        </div>
-      </div>
-    </Wipe>
-  );
+      </Wipe>
+    );
+  }
 
   renderEdges() {
     const edges = get(this.props.variableRegistry, 'edge', {});

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -4,18 +4,48 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { map, has, get } from 'lodash';
-import Color from 'color';
 import { TransitionGroup } from 'react-transition-group';
 import { Wipe } from '../Transitions';
-import { Zoomer } from '../../behaviours/Zoom';
 import { Node, Icon, Button } from '../../ui/components';
 import { Guided } from '../Guided';
 import Guidance from '../Guidance';
 import Card from '../Card';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as variableRegistryActions } from '../../ducks/modules/protocol/variableRegistry';
-import { getCSSVariableAsString } from '../../utils/CSSVariables';
 
+const Type = ({ label, link, children, handleDelete }) => (
+  <div className="list__item">
+    <div className="list__attribute list__attribute--icon">
+      <Link to={link}>
+        {children}
+      </Link>
+    </div>
+    <div className="list__attribute">
+      <h3>
+        <Link to={link}>
+          {label}
+        </Link>
+      </h3>
+    </div>
+    <div className="list__attribute list__attribute--options">
+      <Button size="small" color="neon-coral" onClick={handleDelete}>
+        Delete
+      </Button>
+    </div>
+  </div>
+);
+
+Type.propTypes = {
+  label: PropTypes.string.isRequired,
+  link: PropTypes.string.isRequired,
+  handleDelete: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+/**
+ * This component acts as an index for types. i.e. Nodes and Edges,
+ * and links to the EditType.
+ */
 class VariableRegistry extends Component {
   handleDelete = (category, type) => {
     this.props.deleteType(category, type);
@@ -23,73 +53,32 @@ class VariableRegistry extends Component {
 
   renderNode = (node, key) => {
     const nodeColor = get(node, 'color', '');
-    const nodeColorHex = Color(getCSSVariableAsString(`--${nodeColor}`)).hex();
-    const nodeZoomColors = [nodeColorHex, '#fff'];
+
     return (
       <Wipe key={key}>
-        <div className="list__item" key={key}>
-          <div className="list__attribute list__attribute--icon">
-            <Zoomer zoomColors={nodeZoomColors}>
-              {() => (
-                <Link to={`${this.props.protocolPath}/registry/node/${key}`}>
-                  <Node label="" color={get(node, 'color', '')} />
-                </Link>
-              )}
-            </Zoomer>
-          </div>
-          <div className="list__attribute">
-            <Zoomer zoomColors={nodeZoomColors}>
-              {() => (
-                <h3>
-                  <Link to={`${this.props.protocolPath}/registry/node/${key}`}>
-                    {key}
-                  </Link>
-                </h3>
-              )}
-            </Zoomer>
-          </div>
-          <div className="list__attribute list__attribute--options">
-            <Button size="small" color="neon-coral" onClick={() => this.handleDelete('node', key)}>
-              Delete
-            </Button>
-          </div>
-        </div>
+        <Type
+          link={`${this.props.protocolPath}/registry/node/${key}`}
+          label={key}
+          handleDelete={() => this.handleDelete('node', key)}
+        >
+          <Node label="" color={nodeColor} />
+        </Type>
       </Wipe>
     );
   }
 
   renderEdge = (edge, key) => {
     const edgeColor = get(edge, 'color', '');
-    const edgeColorHex = Color(getCSSVariableAsString(`--color-${edgeColor}`)).hex();
-    const edgeZoomColors = [edgeColorHex, '#fff'];
 
     return (
       <Wipe key={key}>
-        <div className="list__item" key={key}>
-          <div className="list__attribute list__attribute--icon">
-            <Zoomer zoomColors={edgeZoomColors}>
-              {() => (
-                <Link to={`${this.props.protocolPath}/registry/edge/${key}`}>
-                  <Icon name="links" color={get(edge, 'color', '')} />
-                </Link>
-              )}
-            </Zoomer>
-          </div>
-          <div className="list__attribute">
-            <Zoomer zoomColors={edgeZoomColors}>
-              {() => (
-                <h3>
-                  <Link to={`${this.props.protocolPath}/registry/edge/${key}`}>
-                    {key}
-                  </Link>
-                </h3>
-              )}
-            </Zoomer>
-          </div>
-          <div className="list__attribute list__attribute--options">
-            <Button size="small" color="neon-coral" onClick={() => this.handleDelete('edge', key)}>Delete</Button>
-          </div>
-        </div>
+        <Type
+          link={`${this.props.protocolPath}/registry/edge/${key}`}
+          label={key}
+          handleDelete={() => this.handleDelete('edge', key)}
+        >
+          <Icon name="links" color={edgeColor} />
+        </Type>
       </Wipe>
     );
   }

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -13,7 +13,6 @@ import Card from '../Card';
 import { getProtocol } from '../../selectors/protocol';
 import { actionCreators as variableRegistryActions } from '../../ducks/modules/protocol/variableRegistry';
 
-
 class VariableRegistry extends Component {
   handleDelete = (category, type) => {
     this.props.deleteType(category, type);

--- a/src/components/Cards/ViewForms.js
+++ b/src/components/Cards/ViewForms.js
@@ -122,6 +122,8 @@ ViewForms.defaultProps = {
 const mapStateToProps = (state, props) => {
   const protocol = getProtocol(state);
 
+  console.log({ match: props.match });
+
   return {
     forms: get(protocol, 'forms', {}),
     nodes: get(protocol, 'variableRegistry.node', {}),

--- a/src/components/Cards/ViewForms.js
+++ b/src/components/Cards/ViewForms.js
@@ -1,0 +1,142 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { map, has, get } from 'lodash';
+import { TransitionGroup } from 'react-transition-group';
+import { Wipe } from '../Transitions';
+import { Node, Button } from '../../ui/components';
+import { Guided } from '../Guided';
+import Guidance from '../Guidance';
+import Card from '../Card';
+import { getProtocol } from '../../selectors/protocol';
+import { actionCreators as formActions } from '../../ducks/modules/protocol/forms';
+
+class ViewForms extends Component {
+  handleDelete = (form) => {
+    this.props.deleteForm(form);
+  };
+
+  renderForm = (form, key) => (
+    <Wipe key={key}>
+      <div className="list__item" key={key}>
+        <div className="list__attribute list__attribute--icon">
+          <Link to={`${this.props.protocolPath}/form/${key}`}>
+            <Node label={form.type} color={get(this.props.nodes, [form.type, 'color'], '')} />
+          </Link>
+        </div>
+        <div className="list__attribute">
+          <h3>
+            <Link to={`${this.props.protocolPath}/form/${key}`}>
+              {key}
+            </Link>
+          </h3>
+        </div>
+        <div className="list__attribute list__attribute--options">
+          <Button size="small" color="neon-coral" onClick={() => this.handleDelete(key)}>
+            Delete
+          </Button>
+        </div>
+      </div>
+    </Wipe>
+  );
+
+  renderForms() {
+    const forms = this.props.forms;
+
+    if (forms.length === 0) {
+      return 'No forms defined';
+    }
+
+    return (
+      <div className="list">
+        <TransitionGroup>
+          {map(forms, this.renderForm)}
+        </TransitionGroup>
+      </div>
+    );
+  }
+
+  renderButtons() {
+    return ([
+      <Button key="cancel" size="small" color="platinum" onClick={this.props.onComplete}>Back</Button>,
+    ]);
+  }
+
+  render() {
+    const {
+      show,
+      protocolPath,
+    } = this.props;
+
+    if (!protocolPath) { return null; }
+
+    return (
+      <Card
+        show={show}
+        buttons={this.renderButtons()}
+      >
+        <div className="editor variable-registry">
+          <Guided className="editor__sections">
+            <h1>Forms</h1>
+
+            <Guidance contentId="guidance.forms.index">
+              <div className="editor__section">
+                <h2>Forms</h2>
+                <div className="editor__subsection">
+                  {this.renderForms()}
+                </div>
+                <div className="editor__subsection">
+                  <Link
+                    to={`${protocolPath}/form/`}
+                    className="button button--small"
+                  >
+                    Create new Form
+                  </Link>
+                </div>
+              </div>
+            </Guidance>
+          </Guided>
+        </div>
+      </Card>
+    );
+  }
+}
+
+ViewForms.propTypes = {
+  show: PropTypes.bool,
+  forms: PropTypes.object.isRequired,
+  nodes: PropTypes.object.isRequired,
+  protocolPath: PropTypes.string,
+  onComplete: PropTypes.func,
+  deleteForm: PropTypes.func.isRequired,
+};
+
+ViewForms.defaultProps = {
+  protocolPath: null,
+  show: true,
+  onComplete: () => {},
+};
+
+const mapStateToProps = (state, props) => {
+  const protocol = getProtocol(state);
+
+  return {
+    forms: get(protocol, 'forms', {}),
+    nodes: get(protocol, 'variableRegistry.node', {}),
+    protocolPath: has(props, 'match.params.protocol') ?
+      `/edit/${get(props, 'match.params.protocol')}` : null,
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  deleteForm: bindActionCreators(formActions.deleteForm, dispatch),
+});
+
+export { ViewForms };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ViewForms);

--- a/src/components/Cards/ViewForms.js
+++ b/src/components/Cards/ViewForms.js
@@ -5,8 +5,8 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { map, has, get } from 'lodash';
 import { TransitionGroup } from 'react-transition-group';
-import { Wipe } from '../Transitions';
 import { Node, Button } from '../../ui/components';
+import { Wipe } from '../Transitions';
 import { Guided } from '../Guided';
 import Guidance from '../Guidance';
 import Card from '../Card';
@@ -121,8 +121,6 @@ ViewForms.defaultProps = {
 
 const mapStateToProps = (state, props) => {
   const protocol = getProtocol(state);
-
-  console.log({ match: props.match });
 
   return {
     forms: get(protocol, 'forms', {}),

--- a/src/components/Cards/ViewForms.js
+++ b/src/components/Cards/ViewForms.js
@@ -15,7 +15,9 @@ import { actionCreators as formActions } from '../../ducks/modules/protocol/form
 
 class ViewForms extends Component {
   handleDelete = (form) => {
-    this.props.deleteForm(form);
+    if (confirm(`Are you sure you want to delete "${form}"?`)) {
+      this.props.deleteForm(form);
+    }
   };
 
   renderForm = (form, key) => (

--- a/src/components/Cards/ViewForms.js
+++ b/src/components/Cards/ViewForms.js
@@ -15,6 +15,7 @@ import { actionCreators as formActions } from '../../ducks/modules/protocol/form
 
 class ViewForms extends Component {
   handleDelete = (form) => {
+    // eslint-disable-next-line no-alert
     if (confirm(`Are you sure you want to delete "${form}"?`)) {
       this.props.deleteForm(form);
     }

--- a/src/components/Cards/ViewForms.js
+++ b/src/components/Cards/ViewForms.js
@@ -70,8 +70,6 @@ class ViewForms extends Component {
       protocolPath,
     } = this.props;
 
-    if (!protocolPath) { return null; }
-
     return (
       <Card
         show={show}
@@ -87,14 +85,16 @@ class ViewForms extends Component {
                 <div className="editor__subsection">
                   {this.renderForms()}
                 </div>
-                <div className="editor__subsection">
-                  <Link
-                    to={`${protocolPath}/form/`}
-                    className="button button--small"
-                  >
-                    Create new Form
-                  </Link>
-                </div>
+                { protocolPath &&
+                  <div className="editor__subsection">
+                    <Link
+                      to={`${protocolPath}/form/`}
+                      className="button button--small"
+                    >
+                      Create new Form
+                    </Link>
+                  </div>
+                }
               </div>
             </Guidance>
           </Guided>

--- a/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
+++ b/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
@@ -23,9 +23,1029 @@ ShallowWrapper {
     "simulateEvent": [Function],
     "unmount": [Function],
   },
-  Symbol(enzyme.__node__): null,
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "buttons": Array [
+        <Button
+          color="platinum"
+          content=""
+          icon=""
+          iconPosition="right"
+          onClick={[Function]}
+          size="small"
+>
+          Back
+</Button>,
+      ],
+      "children": <div
+        className="editor variable-registry"
+>
+        <Connect(Guided)
+                className="editor__sections"
+        >
+                <h1>
+                        Variable Registry
+                </h1>
+                <Connect(Guided)
+                        contentId="guidance.registry.nodes"
+                >
+                        <div
+                                className="editor__section"
+                        >
+                                <h2>
+                                        Nodes
+                                </h2>
+                                <div
+                                        className="editor__subsection"
+                                >
+                                        <div
+                                                className="list"
+                                        >
+                                                <TransitionGroup
+                                                        childFactory={[Function]}
+                                                        component="div"
+                                                >
+                                                        
+                                                </TransitionGroup>
+                                        </div>
+                                </div>
+                                
+                        </div>
+                </Connect(Guided)>
+                <Connect(Guided)
+                        contentId="guidance.registry.edges"
+                >
+                        <div
+                                className="editor__section"
+                        >
+                                <h2>
+                                        Edges
+                                </h2>
+                                <div
+                                        className="editor__subsection"
+                                >
+                                        <div
+                                                className="list"
+                                        >
+                                                <TransitionGroup
+                                                        childFactory={[Function]}
+                                                        component="div"
+                                                >
+                                                        
+                                                </TransitionGroup>
+                                        </div>
+                                </div>
+                                <div
+                                        className="editor__subsection"
+                                />
+                        </div>
+                </Connect(Guided)>
+        </Connect(Guided)>
+</div>,
+      "enterDelay": 100,
+      "enterDuration": 200,
+      "exitDelay": 0,
+      "exitDuration": 100,
+      "show": true,
+      "style": "wipe",
+      "type": "default",
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <Connect(Guided)
+          className="editor__sections"
+>
+          <h1>
+                    Variable Registry
+          </h1>
+          <Connect(Guided)
+                    contentId="guidance.registry.nodes"
+          >
+                    <div
+                              className="editor__section"
+                    >
+                              <h2>
+                                        Nodes
+                              </h2>
+                              <div
+                                        className="editor__subsection"
+                              >
+                                        <div
+                                                  className="list"
+                                        >
+                                                  <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component="div"
+                                                  >
+                                                            
+                                                  </TransitionGroup>
+                                        </div>
+                              </div>
+                              
+                    </div>
+          </Connect(Guided)>
+          <Connect(Guided)
+                    contentId="guidance.registry.edges"
+          >
+                    <div
+                              className="editor__section"
+                    >
+                              <h2>
+                                        Edges
+                              </h2>
+                              <div
+                                        className="editor__subsection"
+                              >
+                                        <div
+                                                  className="list"
+                                        >
+                                                  <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component="div"
+                                                  >
+                                                            
+                                                  </TransitionGroup>
+                                        </div>
+                              </div>
+                              <div
+                                        className="editor__subsection"
+                              />
+                    </div>
+          </Connect(Guided)>
+</Connect(Guided)>,
+        "className": "editor variable-registry",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": Array [
+            <h1>
+              Variable Registry
+</h1>,
+            <Connect(Guided)
+              contentId="guidance.registry.nodes"
+>
+              <div
+                            className="editor__section"
+              >
+                            <h2>
+                                          Nodes
+                            </h2>
+                            <div
+                                          className="editor__subsection"
+                            >
+                                          <div
+                                                        className="list"
+                                          >
+                                                        <TransitionGroup
+                                                                      childFactory={[Function]}
+                                                                      component="div"
+                                                        >
+                                                                      
+                                                        </TransitionGroup>
+                                          </div>
+                            </div>
+                            
+              </div>
+</Connect(Guided)>,
+            <Connect(Guided)
+              contentId="guidance.registry.edges"
+>
+              <div
+                            className="editor__section"
+              >
+                            <h2>
+                                          Edges
+                            </h2>
+                            <div
+                                          className="editor__subsection"
+                            >
+                                          <div
+                                                        className="list"
+                                          >
+                                                        <TransitionGroup
+                                                                      childFactory={[Function]}
+                                                                      component="div"
+                                                        >
+                                                                      
+                                                        </TransitionGroup>
+                                          </div>
+                            </div>
+                            <div
+                                          className="editor__subsection"
+                            />
+              </div>
+</Connect(Guided)>,
+          ],
+          "className": "editor__sections",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Variable Registry",
+            },
+            "ref": null,
+            "rendered": "Variable Registry",
+            "type": "h1",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": <div
+                className="editor__section"
+>
+                <h2>
+                                Nodes
+                </h2>
+                <div
+                                className="editor__subsection"
+                >
+                                <div
+                                                className="list"
+                                >
+                                                <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component="div"
+                                                >
+                                                                
+                                                </TransitionGroup>
+                                </div>
+                </div>
+                
+</div>,
+              "contentId": "guidance.registry.nodes",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <h2>
+                    Nodes
+</h2>,
+                  <div
+                    className="editor__subsection"
+>
+                    <div
+                                        className="list"
+                    >
+                                        <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component="div"
+                                        >
+                                                            
+                                        </TransitionGroup>
+                    </div>
+</div>,
+                  "",
+                ],
+                "className": "editor__section",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Nodes",
+                  },
+                  "ref": null,
+                  "rendered": "Nodes",
+                  "type": "h2",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <div
+                      className="list"
+>
+                      <TransitionGroup
+                                            childFactory={[Function]}
+                                            component="div"
+                      >
+                                            
+                      </TransitionGroup>
+</div>,
+                    "className": "editor__subsection",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <TransitionGroup
+                        childFactory={[Function]}
+                        component="div"
+>
+                        
+</TransitionGroup>,
+                      "className": "list",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "childFactory": [Function],
+                        "children": Array [],
+                        "component": "div",
+                      },
+                      "ref": null,
+                      "rendered": Array [],
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                  "type": "div",
+                },
+                "",
+              ],
+              "type": "div",
+            },
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": <div
+                className="editor__section"
+>
+                <h2>
+                                Edges
+                </h2>
+                <div
+                                className="editor__subsection"
+                >
+                                <div
+                                                className="list"
+                                >
+                                                <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component="div"
+                                                >
+                                                                
+                                                </TransitionGroup>
+                                </div>
+                </div>
+                <div
+                                className="editor__subsection"
+                />
+</div>,
+              "contentId": "guidance.registry.edges",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <h2>
+                    Edges
+</h2>,
+                  <div
+                    className="editor__subsection"
+>
+                    <div
+                                        className="list"
+                    >
+                                        <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component="div"
+                                        >
+                                                            
+                                        </TransitionGroup>
+                    </div>
+</div>,
+                  <div
+                    className="editor__subsection"
+/>,
+                ],
+                "className": "editor__section",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Edges",
+                  },
+                  "ref": null,
+                  "rendered": "Edges",
+                  "type": "h2",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <div
+                      className="list"
+>
+                      <TransitionGroup
+                                            childFactory={[Function]}
+                                            component="div"
+                      >
+                                            
+                      </TransitionGroup>
+</div>,
+                    "className": "editor__subsection",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <TransitionGroup
+                        childFactory={[Function]}
+                        component="div"
+>
+                        
+</TransitionGroup>,
+                      "className": "list",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "childFactory": [Function],
+                        "children": Array [],
+                        "component": "div",
+                      },
+                      "ref": null,
+                      "rendered": Array [],
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                  "type": "div",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "",
+                    "className": "editor__subsection",
+                  },
+                  "ref": null,
+                  "rendered": "",
+                  "type": "div",
+                },
+              ],
+              "type": "div",
+            },
+            "type": [Function],
+          },
+        ],
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    "type": [Function],
+  },
   Symbol(enzyme.__nodes__): Array [
-    null,
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "buttons": Array [
+          <Button
+            color="platinum"
+            content=""
+            icon=""
+            iconPosition="right"
+            onClick={[Function]}
+            size="small"
+>
+            Back
+</Button>,
+        ],
+        "children": <div
+          className="editor variable-registry"
+>
+          <Connect(Guided)
+                    className="editor__sections"
+          >
+                    <h1>
+                              Variable Registry
+                    </h1>
+                    <Connect(Guided)
+                              contentId="guidance.registry.nodes"
+                    >
+                              <div
+                                        className="editor__section"
+                              >
+                                        <h2>
+                                                  Nodes
+                                        </h2>
+                                        <div
+                                                  className="editor__subsection"
+                                        >
+                                                  <div
+                                                            className="list"
+                                                  >
+                                                            <TransitionGroup
+                                                                      childFactory={[Function]}
+                                                                      component="div"
+                                                            >
+                                                                      
+                                                            </TransitionGroup>
+                                                  </div>
+                                        </div>
+                                        
+                              </div>
+                    </Connect(Guided)>
+                    <Connect(Guided)
+                              contentId="guidance.registry.edges"
+                    >
+                              <div
+                                        className="editor__section"
+                              >
+                                        <h2>
+                                                  Edges
+                                        </h2>
+                                        <div
+                                                  className="editor__subsection"
+                                        >
+                                                  <div
+                                                            className="list"
+                                                  >
+                                                            <TransitionGroup
+                                                                      childFactory={[Function]}
+                                                                      component="div"
+                                                            >
+                                                                      
+                                                            </TransitionGroup>
+                                                  </div>
+                                        </div>
+                                        <div
+                                                  className="editor__subsection"
+                                        />
+                              </div>
+                    </Connect(Guided)>
+          </Connect(Guided)>
+</div>,
+        "enterDelay": 100,
+        "enterDuration": 200,
+        "exitDelay": 0,
+        "exitDuration": 100,
+        "show": true,
+        "style": "wipe",
+        "type": "default",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <Connect(Guided)
+            className="editor__sections"
+>
+            <h1>
+                        Variable Registry
+            </h1>
+            <Connect(Guided)
+                        contentId="guidance.registry.nodes"
+            >
+                        <div
+                                    className="editor__section"
+                        >
+                                    <h2>
+                                                Nodes
+                                    </h2>
+                                    <div
+                                                className="editor__subsection"
+                                    >
+                                                <div
+                                                            className="list"
+                                                >
+                                                            <TransitionGroup
+                                                                        childFactory={[Function]}
+                                                                        component="div"
+                                                            >
+                                                                        
+                                                            </TransitionGroup>
+                                                </div>
+                                    </div>
+                                    
+                        </div>
+            </Connect(Guided)>
+            <Connect(Guided)
+                        contentId="guidance.registry.edges"
+            >
+                        <div
+                                    className="editor__section"
+                        >
+                                    <h2>
+                                                Edges
+                                    </h2>
+                                    <div
+                                                className="editor__subsection"
+                                    >
+                                                <div
+                                                            className="list"
+                                                >
+                                                            <TransitionGroup
+                                                                        childFactory={[Function]}
+                                                                        component="div"
+                                                            >
+                                                                        
+                                                            </TransitionGroup>
+                                                </div>
+                                    </div>
+                                    <div
+                                                className="editor__subsection"
+                                    />
+                        </div>
+            </Connect(Guided)>
+</Connect(Guided)>,
+          "className": "editor variable-registry",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [
+              <h1>
+                Variable Registry
+</h1>,
+              <Connect(Guided)
+                contentId="guidance.registry.nodes"
+>
+                <div
+                                className="editor__section"
+                >
+                                <h2>
+                                                Nodes
+                                </h2>
+                                <div
+                                                className="editor__subsection"
+                                >
+                                                <div
+                                                                className="list"
+                                                >
+                                                                <TransitionGroup
+                                                                                childFactory={[Function]}
+                                                                                component="div"
+                                                                >
+                                                                                
+                                                                </TransitionGroup>
+                                                </div>
+                                </div>
+                                
+                </div>
+</Connect(Guided)>,
+              <Connect(Guided)
+                contentId="guidance.registry.edges"
+>
+                <div
+                                className="editor__section"
+                >
+                                <h2>
+                                                Edges
+                                </h2>
+                                <div
+                                                className="editor__subsection"
+                                >
+                                                <div
+                                                                className="list"
+                                                >
+                                                                <TransitionGroup
+                                                                                childFactory={[Function]}
+                                                                                component="div"
+                                                                >
+                                                                                
+                                                                </TransitionGroup>
+                                                </div>
+                                </div>
+                                <div
+                                                className="editor__subsection"
+                                />
+                </div>
+</Connect(Guided)>,
+            ],
+            "className": "editor__sections",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Variable Registry",
+              },
+              "ref": null,
+              "rendered": "Variable Registry",
+              "type": "h1",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": <div
+                  className="editor__section"
+>
+                  <h2>
+                                    Nodes
+                  </h2>
+                  <div
+                                    className="editor__subsection"
+                  >
+                                    <div
+                                                      className="list"
+                                    >
+                                                      <TransitionGroup
+                                                                        childFactory={[Function]}
+                                                                        component="div"
+                                                      >
+                                                                        
+                                                      </TransitionGroup>
+                                    </div>
+                  </div>
+                  
+</div>,
+                "contentId": "guidance.registry.nodes",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <h2>
+                      Nodes
+</h2>,
+                    <div
+                      className="editor__subsection"
+>
+                      <div
+                                            className="list"
+                      >
+                                            <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component="div"
+                                            >
+                                                                  
+                                            </TransitionGroup>
+                      </div>
+</div>,
+                    "",
+                  ],
+                  "className": "editor__section",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Nodes",
+                    },
+                    "ref": null,
+                    "rendered": "Nodes",
+                    "type": "h2",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <div
+                        className="list"
+>
+                        <TransitionGroup
+                                                childFactory={[Function]}
+                                                component="div"
+                        >
+                                                
+                        </TransitionGroup>
+</div>,
+                      "className": "editor__subsection",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <TransitionGroup
+                          childFactory={[Function]}
+                          component="div"
+>
+                          
+</TransitionGroup>,
+                        "className": "list",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "childFactory": [Function],
+                          "children": Array [],
+                          "component": "div",
+                        },
+                        "ref": null,
+                        "rendered": Array [],
+                        "type": [Function],
+                      },
+                      "type": "div",
+                    },
+                    "type": "div",
+                  },
+                  "",
+                ],
+                "type": "div",
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": <div
+                  className="editor__section"
+>
+                  <h2>
+                                    Edges
+                  </h2>
+                  <div
+                                    className="editor__subsection"
+                  >
+                                    <div
+                                                      className="list"
+                                    >
+                                                      <TransitionGroup
+                                                                        childFactory={[Function]}
+                                                                        component="div"
+                                                      >
+                                                                        
+                                                      </TransitionGroup>
+                                    </div>
+                  </div>
+                  <div
+                                    className="editor__subsection"
+                  />
+</div>,
+                "contentId": "guidance.registry.edges",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <h2>
+                      Edges
+</h2>,
+                    <div
+                      className="editor__subsection"
+>
+                      <div
+                                            className="list"
+                      >
+                                            <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component="div"
+                                            >
+                                                                  
+                                            </TransitionGroup>
+                      </div>
+</div>,
+                    <div
+                      className="editor__subsection"
+/>,
+                  ],
+                  "className": "editor__section",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Edges",
+                    },
+                    "ref": null,
+                    "rendered": "Edges",
+                    "type": "h2",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <div
+                        className="list"
+>
+                        <TransitionGroup
+                                                childFactory={[Function]}
+                                                component="div"
+                        >
+                                                
+                        </TransitionGroup>
+</div>,
+                      "className": "editor__subsection",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <TransitionGroup
+                          childFactory={[Function]}
+                          component="div"
+>
+                          
+</TransitionGroup>,
+                        "className": "list",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "childFactory": [Function],
+                          "children": Array [],
+                          "component": "div",
+                        },
+                        "ref": null,
+                        "rendered": Array [],
+                        "type": [Function],
+                      },
+                      "type": "div",
+                    },
+                    "type": "div",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "",
+                      "className": "editor__subsection",
+                    },
+                    "ref": null,
+                    "rendered": "",
+                    "type": "div",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
+        "type": "div",
+      },
+      "type": [Function],
+    },
   ],
   Symbol(enzyme.__options__): Object {
     "adapter": ReactSixteenAdapter {

--- a/src/components/Form/MultiSelect.js
+++ b/src/components/Form/MultiSelect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { compose, defaultProps, withProps } from 'recompose';
+import { compose, defaultProps, withProps, withHandlers } from 'recompose';
 import { SortableElement, SortableHandle, SortableContainer } from 'react-sortable-hoc';
 import { FieldArray, formValueSelector } from 'redux-form';
 import { Icon } from '../../ui/components';
@@ -37,9 +37,23 @@ const Item = compose(
       allValues: formValueSelector(form)(state, fieldsName),
     }),
   ),
+  withHandlers(({ fields, sortIndex: index }) => ({
+    handleDelete: () => {
+      if (confirm('Are you sure you want to remove this item?')) {
+        fields.remove(index);
+      }
+    },
+  })),
   SortableElement,
 )(
-  ({ fields, field, properties, options, rowValues, allValues, sortIndex: index }) => (
+  ({
+    field,
+    properties,
+    options,
+    rowValues,
+    allValues,
+    handleDelete,
+  }) => (
     <div className="form-fields-multi-select__rule">
       <div className="form-fields-multi-select__rule-control">
         <ItemHandle />
@@ -62,7 +76,7 @@ const Item = compose(
         )}
       </div>
       <div className="form-fields-multi-select__rule-control">
-        <ItemDelete onClick={() => fields.remove(index)} />
+        <ItemDelete onClick={handleDelete} />
       </div>
     </div>
   ),

--- a/src/components/Form/MultiSelect.js
+++ b/src/components/Form/MultiSelect.js
@@ -39,6 +39,7 @@ const Item = compose(
   ),
   withHandlers(({ fields, sortIndex: index }) => ({
     handleDelete: () => {
+      // eslint-disable-next-line no-alert
       if (confirm('Are you sure you want to remove this item?')) {
         fields.remove(index);
       }

--- a/src/components/FormEditor/FormEditor.js
+++ b/src/components/FormEditor/FormEditor.js
@@ -140,7 +140,6 @@ class FormEditor extends Component {
                 component={ArchitectFields.Mode}
                 label="Enable 'Add another' option"
                 options={[[true, 'enabled'], [false, 'disabled']]}
-                validation={{ required: true }}
               />
             </div>
           </Guidance>

--- a/src/components/FormEditor/FormEditor.js
+++ b/src/components/FormEditor/FormEditor.js
@@ -125,9 +125,9 @@ class FormEditor extends Component {
           <div className="stage-editor-section">
             <ValidatedField
               name="optionToAddAnother"
-              component={ArchitectFields.Mode}
-              label="Enable 'Add another' option"
-              options={[[true, 'enabled'], [false, 'disabled']]}
+              component={Fields.Toggle}
+              fieldLabel="Continuous entry"
+              label="Enable 'Add another' option in form"
             />
           </div>
         </Guidance>

--- a/src/components/FormEditor/FormEditor.js
+++ b/src/components/FormEditor/FormEditor.js
@@ -1,15 +1,11 @@
 import React, { Component } from 'react';
-import { Form } from 'redux-form';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import { get, keys, map, toPairs, fromPairs } from 'lodash';
 import { ValidatedField, MultiSelect } from '../Form';
 import * as Fields from '../../ui/components/Fields';
 import * as ArchitectFields from '../Form/Fields';
-import { Guided } from '../Guided';
 import Guidance from '../Guidance';
 import Disable from '../Disable';
-import { FormCodeView } from '../CodeView';
 import NodeType from './NodeType';
 
 const allowedTypes = ['text', 'number', 'boolean'];
@@ -61,105 +57,93 @@ class FormEditor extends Component {
     const {
       nodeTypes,
       variables,
-      handleSubmit,
       toggleCodeView,
-      codeView,
-      form,
       dirty,
       valid,
     } = this.props;
 
     return (
-      <Form onSubmit={handleSubmit} className={cx('stage-editor', { 'stage-editor--show-code': codeView })}>
-        <FormCodeView toggleCodeView={toggleCodeView} form={form} />
-        <Guided
-          className="stage-editor__sections"
-          form={form}
-        >
-          <h1>Edit Form</h1>
-          { dirty && !valid && (
-            <p style={{ color: 'var(--error)' }}>
-              There are some errors that need to be fixed before this can be saved!
-            </p>
-          ) }
-          <small>(<a onClick={toggleCodeView}>Show Code View</a>)</small>
+      <div>
+        <h1>Edit Form</h1>
+        { dirty && !valid && (
+          <p style={{ color: 'var(--error)' }}>
+            There are some errors that need to be fixed before this can be saved!
+          </p>
+        ) }
+        <small>(<a onClick={toggleCodeView}>Show Code View</a>)</small>
 
-          <Guidance contentId="guidance.form.title">
-            <div className="stage-editor-section">
-              <h2>Title</h2>
+        <Guidance contentId="guidance.form.title">
+          <div className="stage-editor-section">
+            <h2>Title</h2>
+            <ValidatedField
+              name="title"
+              component={ArchitectFields.SeamlessText}
+              placeholder="Enter your title here"
+              validation={{ required: true }}
+            />
+          </div>
+        </Guidance>
+
+        <Guidance contentId="guidance.form.type">
+          <div className="stage-editor-section">
+            <h2>Type</h2>
+            <Disable
+              disabled={!!this.props.nodeType}
+              className="stage-editor__reset"
+              onClick={this.props.nodeType ? this.handleAttemptTypeChange : () => {}}
+            >
               <ValidatedField
-                name="title"
-                component={ArchitectFields.SeamlessText}
+                name="type"
+                component={Fields.RadioGroup}
                 placeholder="Enter your title here"
+                className="form-fields-node-select"
+                options={nodeTypes}
                 validation={{ required: true }}
-              />
-            </div>
-          </Guidance>
-
-          <Guidance contentId="guidance.form.type">
-            <div className="stage-editor-section">
-              <h2>Type</h2>
-              <Disable
-                disabled={!!this.props.nodeType}
-                className="stage-editor__reset"
-                onClick={this.props.nodeType ? this.handleAttemptTypeChange : () => {}}
+                optionComponent={NodeType}
               >
-                <ValidatedField
-                  name="type"
-                  component={Fields.RadioGroup}
-                  placeholder="Enter your title here"
-                  className="form-fields-node-select"
-                  options={nodeTypes}
-                  validation={{ required: true }}
-                  optionComponent={NodeType}
-                >
-                  <option value="" disabled>&mdash; Select type &mdash;</option>
-                </ValidatedField>
-              </Disable>
-            </div>
-          </Guidance>
+                <option value="" disabled>&mdash; Select type &mdash;</option>
+              </ValidatedField>
+            </Disable>
+          </div>
+        </Guidance>
 
-          <Guidance contentId="guidance.form.variables">
-            <div className="stage-editor-section">
-              <h2>Form variables</h2>
-              <MultiSelect
-                name="fields"
-                properties={[
-                  'variable',
-                  'component',
-                ]}
-                options={optionGetter(variables)}
-              />
-            </div>
-          </Guidance>
+        <Guidance contentId="guidance.form.variables">
+          <div className="stage-editor-section">
+            <h2>Form variables</h2>
+            <MultiSelect
+              name="fields"
+              properties={[
+                'variable',
+                'component',
+              ]}
+              options={optionGetter(variables)}
+            />
+          </div>
+        </Guidance>
 
-          <Guidance contentId="guidance.form.continue">
-            <div className="stage-editor-section">
-              <ValidatedField
-                name="optionToAddAnother"
-                component={ArchitectFields.Mode}
-                label="Enable 'Add another' option"
-                options={[[true, 'enabled'], [false, 'disabled']]}
-              />
-            </div>
-          </Guidance>
-        </Guided>
-      </Form>
+        <Guidance contentId="guidance.form.continue">
+          <div className="stage-editor-section">
+            <ValidatedField
+              name="optionToAddAnother"
+              component={ArchitectFields.Mode}
+              label="Enable 'Add another' option"
+              options={[[true, 'enabled'], [false, 'disabled']]}
+            />
+          </div>
+        </Guidance>
+      </div>
     );
   }
 }
 
 FormEditor.propTypes = {
   toggleCodeView: PropTypes.func.isRequired,
-  codeView: PropTypes.bool.isRequired,
   dirty: PropTypes.bool.isRequired,
   valid: PropTypes.bool.isRequired,
   resetFields: PropTypes.func.isRequired,
   nodeType: PropTypes.string,
   variables: PropTypes.object.isRequired,
   nodeTypes: PropTypes.array.isRequired,
-  handleSubmit: PropTypes.func.isRequired,
-  form: PropTypes.string.isRequired,
 };
 
 FormEditor.defaultProps = {

--- a/src/components/FormEditor/NodeType.js
+++ b/src/components/FormEditor/NodeType.js
@@ -2,13 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Node } from '../../ui/components';
 
-const NodeType = ({ label, input: { value, checked, onChange } }) => (
-  <Node onClick={() => onChange(value)} label={label} selected={checked} />
+const NodeType = ({
+  label,
+  color,
+  input: { value, checked, onChange },
+}) => (
+  <Node
+    onClick={() => onChange(value)}
+    label={label}
+    selected={checked}
+    color={color}
+  />
 );
 
 NodeType.propTypes = {
   input: PropTypes.object.isRequired,
   label: PropTypes.string.isRequired,
+  color: PropTypes.string,
+};
+
+NodeType.defaultProps = {
+  color: '',
 };
 
 export { NodeType };

--- a/src/components/FormEditor/index.js
+++ b/src/components/FormEditor/index.js
@@ -1,18 +1,17 @@
 import { connect } from 'react-redux';
 import {
-  reduxForm,
   formValueSelector,
   change,
   isDirty,
   isValid,
 } from 'redux-form';
-import { compose, withState, withHandlers } from 'recompose';
+import { compose, withProps } from 'recompose';
 import { keys } from 'lodash';
-import flatten from '../../utils/flatten';
 import { getVariablesForNodeType, getNodeTypes } from '../../selectors/variableRegistry';
+import Editor from '../Editor';
 import FormEditor from './FormEditor';
 
-const formName = 'edit-form';
+const formName = 'EDIT_FORM';
 const getFormValue = formValueSelector(formName);
 const getIsDirty = isDirty(formName);
 const getIsValid = isValid(formName);
@@ -36,20 +35,9 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
+export { formName };
+
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
-  withState('codeView', 'updateCodeView', false),
-  withHandlers({
-    toggleCodeView: ({ updateCodeView }) => () => updateCodeView(current => !current),
-  }),
-  reduxForm({
-    form: formName,
-    touchOnBlur: false,
-    touchOnChange: true,
-    enableReinitialize: true,
-    onSubmitFail: (errors) => {
-      // eslint-disable-next-line no-console
-      console.error('FORM ERRORS', flatten(errors));
-    },
-  }),
-)(FormEditor);
+  withProps(() => ({ form: formName, component: FormEditor })),
+)(Editor);

--- a/src/components/FormEditor/index.js
+++ b/src/components/FormEditor/index.js
@@ -6,7 +6,7 @@ import {
   isValid,
 } from 'redux-form';
 import { compose, withProps } from 'recompose';
-import { keys } from 'lodash';
+import { map, get } from 'lodash';
 import { getVariablesForNodeType, getNodeTypes } from '../../selectors/variableRegistry';
 import Editor from '../Editor';
 import FormEditor from './FormEditor';
@@ -21,7 +21,14 @@ const mapStateToProps = (state) => {
 
   return {
     nodeType: formNodeType,
-    nodeTypes: keys(getNodeTypes(state)),
+    nodeTypes: map(
+      getNodeTypes(state),
+      (nodeOptions, nodeType) => ({
+        label: nodeType,
+        value: nodeType,
+        color: get(nodeOptions, 'color', ''),
+      }),
+    ),
     variables: getVariablesForNodeType(state, formNodeType),
     dirty: getIsDirty(state),
     valid: getIsValid(state),

--- a/src/components/StageEditor/sections/Form.js
+++ b/src/components/StageEditor/sections/Form.js
@@ -59,9 +59,9 @@ class Form extends Component {
     this.showFormEditor();
   };
 
-  handleEditFormComplete = (form) => {
+  handleEditFormComplete = (formName, form) => {
     if (form.type === this.props.nodeType) {
-      this.props.change(form.title);
+      this.props.change(formName);
     }
     this.closeFormEditor();
   };

--- a/src/components/StageEditor/sections/Form.js
+++ b/src/components/StageEditor/sections/Form.js
@@ -8,6 +8,7 @@ import { toPairs, map, get, pickBy } from 'lodash';
 import Guidance from '../../Guidance';
 import { Radio } from '../../../ui/components/Fields';
 import Select from '../../Form/Fields/Select';
+import history from '../../../history';
 
 const DEFAULT_FORM = Symbol('DEFAULT_FORM');
 const CUSTOM_FORM = Symbol('CUSTOM_FORM');
@@ -52,7 +53,7 @@ class Form extends Component {
   };
 
   onClickCreateNewForm = () => {
-    // TODO: Create form popin
+    history.push('/protocols/form');
   };
 
   render() {
@@ -111,7 +112,7 @@ class Form extends Component {
                 </Field>
               </div>
             </div>
-            <div onClick={this.onClickCreateNewForm} className={categoryClasses(true)}>
+            <div onClick={this.onClickCreateNewForm} className={categoryClasses()}>
               <Radio
                 label="Create new form..."
                 className="stage-editor-section-form__radio"

--- a/src/components/Timeline/Overview/Overview.js
+++ b/src/components/Timeline/Overview/Overview.js
@@ -49,8 +49,15 @@ class Overview extends Component {
     return map(
       edgeTypes,
       (edge, key) => (
-        <Link to={this.pathTo(`registry/edge/${key}`)} key={key}>
-          <Icon name="links" label={edge} color={get(edge, 'color', '')} />
+        <Link
+          to={this.pathTo(`registry/edge/${key}`)}
+          key={key}
+          className="timeline-overview__edge"
+          style={{
+            backgroundColor: `var(--${get(edge, 'color', '')})`,
+          }}
+        >
+          <Icon name="links" />
         </Link>
       ),
     );
@@ -99,10 +106,14 @@ class Overview extends Component {
                 <PanelGroup title="Variable registry">
                   <br />
                   <h4>Node types</h4>
-                  { this.renderNodeTypes }
+                  <div>
+                    { this.renderNodeTypes }
+                  </div>
                   <br />
                   <h4>Edge types</h4>
-                  { this.renderEdgeTypes }
+                  <div>
+                    { this.renderEdgeTypes }
+                  </div>
                   <div>
                     <Link className="button button--small" to={this.pathTo('registry')}>
                       Manage registry

--- a/src/components/Timeline/Overview/Overview.js
+++ b/src/components/Timeline/Overview/Overview.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
-import { map, get, keys } from 'lodash';
+import { map, get } from 'lodash';
 import { compose } from 'recompose';
 import { SeamlessText } from '../../Form/Fields';
 import { Tweened } from '../../../behaviours/Tweened';

--- a/src/components/Timeline/Overview/Overview.js
+++ b/src/components/Timeline/Overview/Overview.js
@@ -12,15 +12,6 @@ import { Node, Icon } from '../../../ui';
 import { actionCreators as protocolActions } from '../../../ducks/modules/protocol';
 import PanelGroup from './PanelGroup';
 
-// eslint-disable-next-line
-const renderForm = ({ protocolPath, form }) => (
-  <li key={form}>
-    <Link to={`${protocolPath}/form/${form}`}>
-      {form}
-    </Link>
-  </li>
-);
-
 class Overview extends Component {
   get renderNodeTypes() {
     const nodeTypes = get(this.props.variableRegistry, 'node', {});
@@ -72,7 +63,16 @@ class Overview extends Component {
 
     return (
       <ul>
-        {map(forms, form => renderForm({ form, protocolPath: this.protocolPath }))}
+        {map(
+          forms,
+          form => (
+            <li key={form}>
+              <Link to={this.pathTo(`form/${form}`)}>
+                {form}
+              </Link>
+            </li>
+          ),
+        )}
       </ul>
     );
   }

--- a/src/components/Timeline/Overview/Overview.js
+++ b/src/components/Timeline/Overview/Overview.js
@@ -4,13 +4,22 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
-import { map, get } from 'lodash';
+import { map, get, keys } from 'lodash';
 import { compose } from 'recompose';
 import { SeamlessText } from '../../Form/Fields';
 import { Tweened } from '../../../behaviours/Tweened';
 import { Node, Icon } from '../../../ui';
 import { actionCreators as protocolActions } from '../../../ducks/modules/protocol';
 import PanelGroup from './PanelGroup';
+
+// eslint-disable-next-line
+const renderForm = ({ protocolPath, form }) => (
+  <li key={form}>
+    <Link to={`${protocolPath}/forms`}>
+      {form}
+    </Link>
+  </li>
+);
 
 class Overview extends Component {
   get protocolPath() {
@@ -52,6 +61,20 @@ class Overview extends Component {
     );
   }
 
+  get renderForms() {
+    const forms = keys(this.props.forms);
+
+    if (forms.length === 0) {
+      return 'No forms defined';
+    }
+
+    return (
+      <ul>
+        {map(forms, form => renderForm({ form, protocolPath: this.protocolPath }))}
+      </ul>
+    );
+  }
+
   render() {
     const {
       name,
@@ -81,7 +104,7 @@ class Overview extends Component {
                   { this.renderEdgeTypes }
                 </PanelGroup>
                 <PanelGroup title="Forms">
-                  <p>Forms not displayed yet.</p>
+                  { this.renderForms }
                 </PanelGroup>
                 <PanelGroup title="Global Options">
                   <p>Version: {version}</p>

--- a/src/components/Timeline/Overview/Overview.js
+++ b/src/components/Timeline/Overview/Overview.js
@@ -15,18 +15,13 @@ import PanelGroup from './PanelGroup';
 // eslint-disable-next-line
 const renderForm = ({ protocolPath, form }) => (
   <li key={form}>
-    <Link to={`${protocolPath}/forms`}>
+    <Link to={`${protocolPath}/form/${form}`}>
       {form}
     </Link>
   </li>
 );
 
 class Overview extends Component {
-  get protocolPath() {
-    const protocol = get(this.props.match, 'params.protocol', '');
-    return `/edit/${protocol}`;
-  }
-
   get renderNodeTypes() {
     const nodeTypes = get(this.props.variableRegistry, 'node', {});
 
@@ -37,7 +32,7 @@ class Overview extends Component {
     return map(
       nodeTypes,
       (node, key) => (
-        <Link to={`${this.protocolPath}/registry/`} key={key}>
+        <Link to={this.pathTo(`registry/node/${key}`)} key={key}>
           <Node label={key} color={get(node, 'color', '')} />
         </Link>
       ),
@@ -53,8 +48,8 @@ class Overview extends Component {
 
     return map(
       edgeTypes,
-      (edge, index) => (
-        <Link to={`${this.protocolPath}/registry/`} key={index}>
+      (edge, key) => (
+        <Link to={this.pathTo(`registry/edge/${key}`)} key={key}>
           <Icon name="links" label={edge} color={get(edge, 'color', '')} />
         </Link>
       ),
@@ -73,6 +68,12 @@ class Overview extends Component {
         {map(forms, form => renderForm({ form, protocolPath: this.protocolPath }))}
       </ul>
     );
+  }
+
+  pathTo(location) {
+    const protocol = get(this.props.match, 'params.protocol');
+    if (!protocol) { return ''; }
+    return `/edit/${protocol}/${location}`;
   }
 
   render() {
@@ -102,9 +103,19 @@ class Overview extends Component {
                   <br />
                   <h4>Edge types</h4>
                   { this.renderEdgeTypes }
+                  <div>
+                    <Link className="button button--small" to={this.pathTo('registry')}>
+                      Manage registry
+                    </Link>
+                  </div>
                 </PanelGroup>
                 <PanelGroup title="Forms">
                   { this.renderForms }
+                  <div>
+                    <Link className="button button--small" to={this.pathTo('forms')}>
+                      Manage forms
+                    </Link>
+                  </div>
                 </PanelGroup>
                 <PanelGroup title="Global Options">
                   <p>Version: {version}</p>

--- a/src/components/Timeline/Overview/Overview.js
+++ b/src/components/Timeline/Overview/Overview.js
@@ -55,7 +55,7 @@ class Overview extends Component {
   }
 
   get renderForms() {
-    const forms = keys(this.props.forms);
+    const forms = this.props.forms;
 
     if (forms.length === 0) {
       return 'No forms defined';
@@ -65,10 +65,10 @@ class Overview extends Component {
       <ul>
         {map(
           forms,
-          form => (
-            <li key={form}>
-              <Link to={this.pathTo(`form/${form}`)}>
-                {form}
+          (form, key) => (
+            <li key={key}>
+              <Link to={this.pathTo(`form/${key}`)}>
+                {form.title}
               </Link>
             </li>
           ),

--- a/src/components/TypeEditor/Options.js
+++ b/src/components/TypeEditor/Options.js
@@ -23,6 +23,7 @@ const AddItem = props => (
 const Item = compose(
   withHandlers(({ fields, index }) => ({
     handleDelete: () => {
+      // eslint-disable-next-line no-alert
       if (confirm('Are you sure you want to remove this item?')) {
         fields.remove(index);
       }

--- a/src/components/TypeEditor/Options.js
+++ b/src/components/TypeEditor/Options.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { compose, withHandlers } from 'recompose';
 import { toNumber } from 'lodash';
 import { Field, FieldArray } from 'redux-form';
 import { Icon } from '../../ui/components';
@@ -19,22 +20,32 @@ const AddItem = props => (
   </div>
 );
 
-const Item = ({ fields, field, index }) => (
-  <div className="form-fields-multi-select__rule">
-    <div className="form-fields-multi-select__rule-options">
-      <div className="form-fields-multi-select__rule-option">
-        <div className="form-fields-multi-select__rule-option-label">Label</div>
-        <Field component="input" type="text" name={`${field}.label`} placeholder="label" />
+const Item = compose(
+  withHandlers(({ fields, index }) => ({
+    handleDelete: () => {
+      if (confirm('Are you sure you want to remove this item?')) {
+        fields.remove(index);
+      }
+    },
+  })),
+)(
+  ({ field, handleDelete }) => (
+    <div className="form-fields-multi-select__rule">
+      <div className="form-fields-multi-select__rule-options">
+        <div className="form-fields-multi-select__rule-option">
+          <div className="form-fields-multi-select__rule-option-label">Label</div>
+          <Field component="input" type="text" name={`${field}.label`} placeholder="label" />
+        </div>
+        <div className="form-fields-multi-select__rule-option">
+          <div className="form-fields-multi-select__rule-option-label">Value</div>
+          <Field component="input" type="text" name={`${field}.value`} parse={value => (isNumberLike(value) ? toNumber(value) : value)} placeholder="value" />
+        </div>
       </div>
-      <div className="form-fields-multi-select__rule-option">
-        <div className="form-fields-multi-select__rule-option-label">Value</div>
-        <Field component="input" type="text" name={`${field}.value`} parse={value => (isNumberLike(value) ? toNumber(value) : value)} placeholder="value" />
+      <div className="form-fields-multi-select__rule-control">
+        <ItemDelete onClick={handleDelete} />
       </div>
     </div>
-    <div className="form-fields-multi-select__rule-control">
-      <ItemDelete onClick={() => fields.remove(index)} />
-    </div>
-  </div>
+  ),
 );
 
 Item.propTypes = {

--- a/src/components/TypeEditor/TypeEditor.js
+++ b/src/components/TypeEditor/TypeEditor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Color from 'color';
+import { get, times } from 'lodash';
 import { Field } from 'redux-form';
 import { getCSSVariableAsString } from '../../utils/CSSVariables';
 import { ValidatedField } from '../Form';
@@ -18,22 +19,17 @@ const getColorByVariable = (variable) => {
   }
 };
 
-const COLOR_OPTIONS = [
-  'color-neon-coral',
-  'color-sea-serpent',
-  'color-purple-pizazz',
-  'color-neon-carrot',
-  'color-kiwi',
-  'color-cerulean-blue',
-  'color-paradise-pink',
-  'color-mustard',
-].map(
-  name =>
-    ({
-      name,
-      color: getColorByVariable(`--${name}`),
-    }),
-);
+const asColorOption = name => ({
+  name,
+  color: getColorByVariable(`--${name}`),
+});
+
+const COLOR_OPTIONS = {
+  node: times(8, index => `node-color-seq-${(index + 1)}`)
+    .map(asColorOption),
+  edge: times(10, index => `edge-color-seq-${(index + 1)}`)
+    .map(asColorOption),
+};
 
 const ICON_OPTIONS = [
   'add-a-context',
@@ -84,7 +80,7 @@ const TypeEditor = ({
         <ValidatedField
           component={ArchitectFields.ColorPicker}
           name="color"
-          colors={COLOR_OPTIONS}
+          colors={get(COLOR_OPTIONS, category, [])}
           validation={{ required: true }}
         />
       </div>

--- a/src/components/TypeEditor/Validations.js
+++ b/src/components/TypeEditor/Validations.js
@@ -81,6 +81,7 @@ const Item = compose(
   ),
   withHandlers(({ fields, index }) => ({
     handleDelete: () => {
+      // eslint-disable-next-line no-alert
       if (confirm('Are you sure you want to remove this item?')) {
         fields.remove(index);
       }

--- a/src/components/TypeEditor/Validations.js
+++ b/src/components/TypeEditor/Validations.js
@@ -27,11 +27,8 @@ const VALIDATION_TYPES = {
   ],
   ordinal: [
     'required',
-    'minSelected',
-    'maxSelected',
-
   ],
-  catagorical: [
+  categorical: [
     'required',
     'minSelected',
     'maxSelected',

--- a/src/components/TypeEditor/Validations.js
+++ b/src/components/TypeEditor/Validations.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { compose } from 'recompose';
+import { compose, withHandlers } from 'recompose';
 import { get, map } from 'lodash';
 import { Field, FieldArray } from 'redux-form';
 import { Icon } from '../../ui/components';
@@ -79,8 +79,15 @@ const Item = compose(
       allValues: fields.getAll(),
     }),
   ),
+  withHandlers(({ fields, index }) => ({
+    handleDelete: () => {
+      if (confirm('Are you sure you want to remove this item?')) {
+        fields.remove(index);
+      }
+    },
+  })),
 )(
-  ({ fields, field, variableType, rowValues, allValues, index }) => (
+  ({ field, variableType, rowValues, allValues, handleDelete }) => (
     <div className="form-fields-multi-select__rule">
       <div className="form-fields-multi-select__rule-options">
         <div className="form-fields-multi-select__rule-option">
@@ -111,7 +118,7 @@ const Item = compose(
         </div>
       </div>
       <div className="form-fields-multi-select__rule-control">
-        <ItemDelete onClick={() => fields.remove(index)} />
+        <ItemDelete onClick={handleDelete} />
       </div>
     </div>
   ),

--- a/src/components/TypeEditor/__tests__/__snapshots__/TypeEditor.test.js.snap
+++ b/src/components/TypeEditor/__tests__/__snapshots__/TypeEditor.test.js.snap
@@ -79,35 +79,43 @@ ShallowWrapper {
                                         Array [
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-neon-coral",
+                                                    "name": "edge-color-seq-1",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-sea-serpent",
+                                                    "name": "edge-color-seq-2",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-purple-pizazz",
+                                                    "name": "edge-color-seq-3",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-neon-carrot",
+                                                    "name": "edge-color-seq-4",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-kiwi",
+                                                    "name": "edge-color-seq-5",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-cerulean-blue",
+                                                    "name": "edge-color-seq-6",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-paradise-pink",
+                                                    "name": "edge-color-seq-7",
                                                   },
                                                   Object {
-                                                    "color": "#117733",
-                                                    "name": "color-mustard",
+                                                    "color": "",
+                                                    "name": "edge-color-seq-8",
+                                                  },
+                                                  Object {
+                                                    "color": "",
+                                                    "name": "edge-color-seq-9",
+                                                  },
+                                                  Object {
+                                                    "color": "",
+                                                    "name": "edge-color-seq-10",
                                                   },
                                                 ]
                               }
@@ -295,35 +303,43 @@ ShallowWrapper {
                                     Array [
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-coral",
+                                                  "name": "edge-color-seq-1",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-sea-serpent",
+                                                  "name": "edge-color-seq-2",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-purple-pizazz",
+                                                  "name": "edge-color-seq-3",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-carrot",
+                                                  "name": "edge-color-seq-4",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-kiwi",
+                                                  "name": "edge-color-seq-5",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-cerulean-blue",
+                                                  "name": "edge-color-seq-6",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-paradise-pink",
+                                                  "name": "edge-color-seq-7",
                                                 },
                                                 Object {
-                                                  "color": "#117733",
-                                                  "name": "color-mustard",
+                                                  "color": "",
+                                                  "name": "edge-color-seq-8",
+                                                },
+                                                Object {
+                                                  "color": "",
+                                                  "name": "edge-color-seq-9",
+                                                },
+                                                Object {
+                                                  "color": "",
+                                                  "name": "edge-color-seq-10",
                                                 },
                                               ]
                         }
@@ -353,35 +369,43 @@ ShallowWrapper {
                                 Array [
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-coral",
+                                                  "name": "edge-color-seq-1",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-sea-serpent",
+                                                  "name": "edge-color-seq-2",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-purple-pizazz",
+                                                  "name": "edge-color-seq-3",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-carrot",
+                                                  "name": "edge-color-seq-4",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-kiwi",
+                                                  "name": "edge-color-seq-5",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-cerulean-blue",
+                                                  "name": "edge-color-seq-6",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-paradise-pink",
+                                                  "name": "edge-color-seq-7",
                                                 },
                                                 Object {
-                                                  "color": "#117733",
-                                                  "name": "color-mustard",
+                                                  "color": "",
+                                                  "name": "edge-color-seq-8",
+                                                },
+                                                Object {
+                                                  "color": "",
+                                                  "name": "edge-color-seq-9",
+                                                },
+                                                Object {
+                                                  "color": "",
+                                                  "name": "edge-color-seq-10",
                                                 },
                                               ]
                 }
@@ -417,35 +441,43 @@ ShallowWrapper {
                 "colors": Array [
                   Object {
                     "color": "",
-                    "name": "color-neon-coral",
+                    "name": "edge-color-seq-1",
                   },
                   Object {
                     "color": "",
-                    "name": "color-sea-serpent",
+                    "name": "edge-color-seq-2",
                   },
                   Object {
                     "color": "",
-                    "name": "color-purple-pizazz",
+                    "name": "edge-color-seq-3",
                   },
                   Object {
                     "color": "",
-                    "name": "color-neon-carrot",
+                    "name": "edge-color-seq-4",
                   },
                   Object {
                     "color": "",
-                    "name": "color-kiwi",
+                    "name": "edge-color-seq-5",
                   },
                   Object {
                     "color": "",
-                    "name": "color-cerulean-blue",
+                    "name": "edge-color-seq-6",
                   },
                   Object {
                     "color": "",
-                    "name": "color-paradise-pink",
+                    "name": "edge-color-seq-7",
                   },
                   Object {
-                    "color": "#117733",
-                    "name": "color-mustard",
+                    "color": "",
+                    "name": "edge-color-seq-8",
+                  },
+                  Object {
+                    "color": "",
+                    "name": "edge-color-seq-9",
+                  },
+                  Object {
+                    "color": "",
+                    "name": "edge-color-seq-10",
                   },
                 ],
                 "component": [Function],
@@ -590,35 +622,43 @@ ShallowWrapper {
                                                 Array [
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-neon-coral",
+                                                              "name": "edge-color-seq-1",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-sea-serpent",
+                                                              "name": "edge-color-seq-2",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-purple-pizazz",
+                                                              "name": "edge-color-seq-3",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-neon-carrot",
+                                                              "name": "edge-color-seq-4",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-kiwi",
+                                                              "name": "edge-color-seq-5",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-cerulean-blue",
+                                                              "name": "edge-color-seq-6",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-paradise-pink",
+                                                              "name": "edge-color-seq-7",
                                                             },
                                                             Object {
-                                                              "color": "#117733",
-                                                              "name": "color-mustard",
+                                                              "color": "",
+                                                              "name": "edge-color-seq-8",
+                                                            },
+                                                            Object {
+                                                              "color": "",
+                                                              "name": "edge-color-seq-9",
+                                                            },
+                                                            Object {
+                                                              "color": "",
+                                                              "name": "edge-color-seq-10",
                                                             },
                                                           ]
                                     }
@@ -806,35 +846,43 @@ ShallowWrapper {
                                           Array [
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-neon-coral",
+                                                          "name": "edge-color-seq-1",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-sea-serpent",
+                                                          "name": "edge-color-seq-2",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-purple-pizazz",
+                                                          "name": "edge-color-seq-3",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-neon-carrot",
+                                                          "name": "edge-color-seq-4",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-kiwi",
+                                                          "name": "edge-color-seq-5",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-cerulean-blue",
+                                                          "name": "edge-color-seq-6",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-paradise-pink",
+                                                          "name": "edge-color-seq-7",
                                                         },
                                                         Object {
-                                                          "color": "#117733",
-                                                          "name": "color-mustard",
+                                                          "color": "",
+                                                          "name": "edge-color-seq-8",
+                                                        },
+                                                        Object {
+                                                          "color": "",
+                                                          "name": "edge-color-seq-9",
+                                                        },
+                                                        Object {
+                                                          "color": "",
+                                                          "name": "edge-color-seq-10",
                                                         },
                                                       ]
                             }
@@ -864,35 +912,43 @@ ShallowWrapper {
                                     Array [
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-neon-coral",
+                                                        "name": "edge-color-seq-1",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-sea-serpent",
+                                                        "name": "edge-color-seq-2",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-purple-pizazz",
+                                                        "name": "edge-color-seq-3",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-neon-carrot",
+                                                        "name": "edge-color-seq-4",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-kiwi",
+                                                        "name": "edge-color-seq-5",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-cerulean-blue",
+                                                        "name": "edge-color-seq-6",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-paradise-pink",
+                                                        "name": "edge-color-seq-7",
                                                       },
                                                       Object {
-                                                        "color": "#117733",
-                                                        "name": "color-mustard",
+                                                        "color": "",
+                                                        "name": "edge-color-seq-8",
+                                                      },
+                                                      Object {
+                                                        "color": "",
+                                                        "name": "edge-color-seq-9",
+                                                      },
+                                                      Object {
+                                                        "color": "",
+                                                        "name": "edge-color-seq-10",
                                                       },
                                                     ]
                   }
@@ -928,35 +984,43 @@ ShallowWrapper {
                   "colors": Array [
                     Object {
                       "color": "",
-                      "name": "color-neon-coral",
+                      "name": "edge-color-seq-1",
                     },
                     Object {
                       "color": "",
-                      "name": "color-sea-serpent",
+                      "name": "edge-color-seq-2",
                     },
                     Object {
                       "color": "",
-                      "name": "color-purple-pizazz",
+                      "name": "edge-color-seq-3",
                     },
                     Object {
                       "color": "",
-                      "name": "color-neon-carrot",
+                      "name": "edge-color-seq-4",
                     },
                     Object {
                       "color": "",
-                      "name": "color-kiwi",
+                      "name": "edge-color-seq-5",
                     },
                     Object {
                       "color": "",
-                      "name": "color-cerulean-blue",
+                      "name": "edge-color-seq-6",
                     },
                     Object {
                       "color": "",
-                      "name": "color-paradise-pink",
+                      "name": "edge-color-seq-7",
                     },
                     Object {
-                      "color": "#117733",
-                      "name": "color-mustard",
+                      "color": "",
+                      "name": "edge-color-seq-8",
+                    },
+                    Object {
+                      "color": "",
+                      "name": "edge-color-seq-9",
+                    },
+                    Object {
+                      "color": "",
+                      "name": "edge-color-seq-10",
                     },
                   ],
                   "component": [Function],
@@ -1133,35 +1197,35 @@ ShallowWrapper {
                                         Array [
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-neon-coral",
+                                                    "name": "node-color-seq-1",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-sea-serpent",
+                                                    "name": "node-color-seq-2",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-purple-pizazz",
+                                                    "name": "node-color-seq-3",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-neon-carrot",
+                                                    "name": "node-color-seq-4",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-kiwi",
+                                                    "name": "node-color-seq-5",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-cerulean-blue",
+                                                    "name": "node-color-seq-6",
                                                   },
                                                   Object {
                                                     "color": "",
-                                                    "name": "color-paradise-pink",
+                                                    "name": "node-color-seq-7",
                                                   },
                                                   Object {
-                                                    "color": "#117733",
-                                                    "name": "color-mustard",
+                                                    "color": "",
+                                                    "name": "node-color-seq-8",
                                                   },
                                                 ]
                               }
@@ -1401,35 +1465,35 @@ ShallowWrapper {
                                     Array [
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-coral",
+                                                  "name": "node-color-seq-1",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-sea-serpent",
+                                                  "name": "node-color-seq-2",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-purple-pizazz",
+                                                  "name": "node-color-seq-3",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-carrot",
+                                                  "name": "node-color-seq-4",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-kiwi",
+                                                  "name": "node-color-seq-5",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-cerulean-blue",
+                                                  "name": "node-color-seq-6",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-paradise-pink",
+                                                  "name": "node-color-seq-7",
                                                 },
                                                 Object {
-                                                  "color": "#117733",
-                                                  "name": "color-mustard",
+                                                  "color": "",
+                                                  "name": "node-color-seq-8",
                                                 },
                                               ]
                         }
@@ -1459,35 +1523,35 @@ ShallowWrapper {
                                 Array [
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-coral",
+                                                  "name": "node-color-seq-1",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-sea-serpent",
+                                                  "name": "node-color-seq-2",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-purple-pizazz",
+                                                  "name": "node-color-seq-3",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-neon-carrot",
+                                                  "name": "node-color-seq-4",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-kiwi",
+                                                  "name": "node-color-seq-5",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-cerulean-blue",
+                                                  "name": "node-color-seq-6",
                                                 },
                                                 Object {
                                                   "color": "",
-                                                  "name": "color-paradise-pink",
+                                                  "name": "node-color-seq-7",
                                                 },
                                                 Object {
-                                                  "color": "#117733",
-                                                  "name": "color-mustard",
+                                                  "color": "",
+                                                  "name": "node-color-seq-8",
                                                 },
                                               ]
                 }
@@ -1523,35 +1587,35 @@ ShallowWrapper {
                 "colors": Array [
                   Object {
                     "color": "",
-                    "name": "color-neon-coral",
+                    "name": "node-color-seq-1",
                   },
                   Object {
                     "color": "",
-                    "name": "color-sea-serpent",
+                    "name": "node-color-seq-2",
                   },
                   Object {
                     "color": "",
-                    "name": "color-purple-pizazz",
+                    "name": "node-color-seq-3",
                   },
                   Object {
                     "color": "",
-                    "name": "color-neon-carrot",
+                    "name": "node-color-seq-4",
                   },
                   Object {
                     "color": "",
-                    "name": "color-kiwi",
+                    "name": "node-color-seq-5",
                   },
                   Object {
                     "color": "",
-                    "name": "color-cerulean-blue",
+                    "name": "node-color-seq-6",
                   },
                   Object {
                     "color": "",
-                    "name": "color-paradise-pink",
+                    "name": "node-color-seq-7",
                   },
                   Object {
-                    "color": "#117733",
-                    "name": "color-mustard",
+                    "color": "",
+                    "name": "node-color-seq-8",
                   },
                 ],
                 "component": [Function],
@@ -1958,35 +2022,35 @@ ShallowWrapper {
                                                 Array [
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-neon-coral",
+                                                              "name": "node-color-seq-1",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-sea-serpent",
+                                                              "name": "node-color-seq-2",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-purple-pizazz",
+                                                              "name": "node-color-seq-3",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-neon-carrot",
+                                                              "name": "node-color-seq-4",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-kiwi",
+                                                              "name": "node-color-seq-5",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-cerulean-blue",
+                                                              "name": "node-color-seq-6",
                                                             },
                                                             Object {
                                                               "color": "",
-                                                              "name": "color-paradise-pink",
+                                                              "name": "node-color-seq-7",
                                                             },
                                                             Object {
-                                                              "color": "#117733",
-                                                              "name": "color-mustard",
+                                                              "color": "",
+                                                              "name": "node-color-seq-8",
                                                             },
                                                           ]
                                     }
@@ -2226,35 +2290,35 @@ ShallowWrapper {
                                           Array [
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-neon-coral",
+                                                          "name": "node-color-seq-1",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-sea-serpent",
+                                                          "name": "node-color-seq-2",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-purple-pizazz",
+                                                          "name": "node-color-seq-3",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-neon-carrot",
+                                                          "name": "node-color-seq-4",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-kiwi",
+                                                          "name": "node-color-seq-5",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-cerulean-blue",
+                                                          "name": "node-color-seq-6",
                                                         },
                                                         Object {
                                                           "color": "",
-                                                          "name": "color-paradise-pink",
+                                                          "name": "node-color-seq-7",
                                                         },
                                                         Object {
-                                                          "color": "#117733",
-                                                          "name": "color-mustard",
+                                                          "color": "",
+                                                          "name": "node-color-seq-8",
                                                         },
                                                       ]
                             }
@@ -2284,35 +2348,35 @@ ShallowWrapper {
                                     Array [
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-neon-coral",
+                                                        "name": "node-color-seq-1",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-sea-serpent",
+                                                        "name": "node-color-seq-2",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-purple-pizazz",
+                                                        "name": "node-color-seq-3",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-neon-carrot",
+                                                        "name": "node-color-seq-4",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-kiwi",
+                                                        "name": "node-color-seq-5",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-cerulean-blue",
+                                                        "name": "node-color-seq-6",
                                                       },
                                                       Object {
                                                         "color": "",
-                                                        "name": "color-paradise-pink",
+                                                        "name": "node-color-seq-7",
                                                       },
                                                       Object {
-                                                        "color": "#117733",
-                                                        "name": "color-mustard",
+                                                        "color": "",
+                                                        "name": "node-color-seq-8",
                                                       },
                                                     ]
                   }
@@ -2348,35 +2412,35 @@ ShallowWrapper {
                   "colors": Array [
                     Object {
                       "color": "",
-                      "name": "color-neon-coral",
+                      "name": "node-color-seq-1",
                     },
                     Object {
                       "color": "",
-                      "name": "color-sea-serpent",
+                      "name": "node-color-seq-2",
                     },
                     Object {
                       "color": "",
-                      "name": "color-purple-pizazz",
+                      "name": "node-color-seq-3",
                     },
                     Object {
                       "color": "",
-                      "name": "color-neon-carrot",
+                      "name": "node-color-seq-4",
                     },
                     Object {
                       "color": "",
-                      "name": "color-kiwi",
+                      "name": "node-color-seq-5",
                     },
                     Object {
                       "color": "",
-                      "name": "color-cerulean-blue",
+                      "name": "node-color-seq-6",
                     },
                     Object {
                       "color": "",
-                      "name": "color-paradise-pink",
+                      "name": "node-color-seq-7",
                     },
                     Object {
-                      "color": "#117733",
-                      "name": "color-mustard",
+                      "color": "",
+                      "name": "node-color-seq-8",
                     },
                   ],
                   "component": [Function],

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -174,14 +174,14 @@ class Protocol extends PureComponent {
         />
 
         <ShowRoute
-          path="/edit/:protocol/forms"
+          path={['/edit/:protocol/form(s?)']}
           location={location}
           component={ViewForms}
           onComplete={this.onRouteComplete}
         />
 
         <ShowRoute
-          path="/edit/:protocol/form/:form?"
+          path={['/edit/:protocol/form/:form']}
           location={location}
           component={EditForm}
           onComplete={this.onRouteComplete}

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -147,7 +147,7 @@ class Protocol extends PureComponent {
         />
 
         <ShowRoute
-          path={'/edit/:protocol/form/:form'}
+          path={'/edit/:protocol/form/:form?'}
           location={location}
           component={EditForm}
           onComplete={this.onRouteComplete}

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -75,10 +75,7 @@ class Protocol extends PureComponent {
   }
 
   createStage = (type, insertAtIndex) =>
-    this.setState(
-      { new: { type, insertAtIndex } },
-      () => this.goto('stage'),
-    );
+    this.goto(`stage?type=${type}&insertAtIndex=${insertAtIndex}`);
 
   editStage = stageId =>
     this.goto(`stage/${stageId}`)
@@ -136,7 +133,6 @@ class Protocol extends PureComponent {
           location={location}
           component={EditStage}
           onComplete={this.onRouteComplete}
-          {...this.state.new}
         />
 
         <ShowRoute

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -83,12 +83,11 @@ class Protocol extends PureComponent {
 
     if (protocol) {
       switch (goto) {
-        case 'registry':
-          history.push(`/edit/${protocol}/registry`);
-          break;
         case 'protocol':
+          history.push(`/edit/${protocol}/`);
+          break;
         default:
-          history.push(`/edit/${protocol}`);
+          history.goBack();
           break;
       }
     }
@@ -177,7 +176,7 @@ class Protocol extends PureComponent {
           path={['/edit/:protocol/form(s?)']}
           location={location}
           component={ViewForms}
-          onComplete={this.onRouteComplete}
+          onComplete={() => this.onRouteComplete('protocol')}
         />
 
         <ShowRoute
@@ -191,14 +190,14 @@ class Protocol extends PureComponent {
           path="/edit/:protocol/registry"
           location={location}
           component={VariableRegistry}
-          onComplete={this.onRouteComplete}
+          onComplete={() => this.onRouteComplete('protocol')}
         />
 
         <ShowRoute
           path="/edit/:protocol/registry/:category/:type?"
           location={location}
           component={EditType}
-          onComplete={() => this.onRouteComplete('registry')}
+          onComplete={this.onRouteComplete}
         />
       </div>
     );

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -12,6 +12,7 @@ import EditSkipLogic from '../Cards/EditSkipLogic';
 import EditStage from '../Cards/EditStage';
 import EditForm from '../Cards/Form';
 import VariableRegistry from '../Cards/VariableRegistry';
+import ViewForms from '../Cards/ViewForms';
 import EditType from '../Cards/EditType';
 import Timeline from '../../components/Timeline';
 import ControlBar from '../ControlBar';
@@ -170,6 +171,13 @@ class Protocol extends PureComponent {
           show={this.isCardVisible(cards.editStage)}
           onComplete={this.onCardComplete}
           onCancel={this.onCardCancel}
+        />
+
+        <ShowRoute
+          path="/edit/:protocol/forms"
+          location={location}
+          component={ViewForms}
+          onComplete={this.onRouteComplete}
         />
 
         <ShowRoute

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -10,7 +10,7 @@ import { getProtocol } from '../../selectors/protocol';
 import ShowRoute from '../../components/ShowRoute';
 import EditSkipLogic from '../Cards/EditSkipLogic';
 import EditStage from '../Cards/EditStage';
-import EditForm from '../Cards/Form';
+import EditForm from '../Cards/EditForm';
 import VariableRegistry from '../Cards/VariableRegistry';
 import ViewForms from '../Cards/ViewForms';
 import EditType from '../Cards/EditType';

--- a/src/components/Views/Protocol.js
+++ b/src/components/Views/Protocol.js
@@ -33,7 +33,6 @@ class Protocol extends PureComponent {
     hasChanges: PropTypes.bool,
     match: PropTypes.object,
     location: PropTypes.object.isRequired,
-    protocol: PropTypes.string.isRequired,
     saveProtocol: PropTypes.func.isRequired,
   };
 
@@ -54,24 +53,24 @@ class Protocol extends PureComponent {
     };
   }
 
-  onRouteComplete = (goto) => {
-    const protocol = get(this.props.match, 'params.protocol');
+  get protocolPath() {
+    return get(this.props.match, 'params.protocol');
+  }
 
-    if (protocol) {
+  handleRouteComplete = (goto) => {
+    if (this.protocolPath) {
       switch (goto) {
         case 'protocol':
-          history.push(`/edit/${protocol}/`);
+          history.push(`/edit/${this.protocolPath}/`);
           break;
         default:
           history.goBack();
-          break;
       }
     }
   }
 
   goto = (location = '') => {
-    const protocol = get(this.props.match, 'params.protocol');
-    history.push(`/edit/${protocol}/${location}`);
+    history.push(`/edit/${this.protocolPath}/${location}`);
   }
 
   createStage = (type, insertAtIndex) =>
@@ -132,35 +131,35 @@ class Protocol extends PureComponent {
           path={'/edit/:protocol/stage/:id?'}
           location={location}
           component={EditStage}
-          onComplete={this.onRouteComplete}
+          onComplete={this.handleRouteComplete}
         />
 
         <ShowRoute
           path={'/edit/:protocol/form(s?)'}
           location={location}
           component={ViewForms}
-          onComplete={() => this.onRouteComplete('protocol')}
+          onComplete={() => this.handleRouteComplete('protocol')}
         />
 
         <ShowRoute
           path={'/edit/:protocol/form/:form?'}
           location={location}
           component={EditForm}
-          onComplete={this.onRouteComplete}
+          onComplete={this.handleRouteComplete}
         />
 
         <ShowRoute
           path="/edit/:protocol/registry"
           location={location}
           component={VariableRegistry}
-          onComplete={() => this.onRouteComplete('protocol')}
+          onComplete={() => this.handleRouteComplete('protocol')}
         />
 
         <ShowRoute
           path="/edit/:protocol/registry/:category/:type?"
           location={location}
           component={EditType}
-          onComplete={this.onRouteComplete}
+          onComplete={this.handleRouteComplete}
         />
       </div>
     );

--- a/src/components/Views/Start/ProtocolStack.js
+++ b/src/components/Views/Start/ProtocolStack.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { get } from 'lodash';
 import Tweened from '../../../behaviours/Tweened';
 import protocolCover from '../../../images/protocol-cover.png';
 
@@ -15,7 +16,7 @@ const Stack = Tweened(() => (
 const getPath = ({ advanced, workingPath, archivePath }) =>
   encodeURIComponent((advanced && workingPath) || archivePath);
 
-const getFilename = path => path.split('\\').pop().split('/').pop();
+const getFilename = (path = '') => get(path.match(/([^/\\]+)$/), 1, '');
 
 const ProtocolStack = ({ protocol: { id, archivePath, workingPath, advanced } }) => (
   <Link

--- a/src/components/Views/Start/Start.js
+++ b/src/components/Views/Start/Start.js
@@ -31,6 +31,7 @@ class Start extends PureComponent {
   }
 
   render() {
+    console.log('protocols', this.props.protocols);
     return (
       <div className="start">
         <div className="start__split">

--- a/src/components/Views/Start/Start.js
+++ b/src/components/Views/Start/Start.js
@@ -31,7 +31,6 @@ class Start extends PureComponent {
   }
 
   render() {
-    console.log('protocols', this.props.protocols);
     return (
       <div className="start">
         <div className="start__split">

--- a/src/components/Views/__tests__/__snapshots__/Protocol.test.js.snap
+++ b/src/components/Views/__tests__/__snapshots__/Protocol.test.js.snap
@@ -94,7 +94,21 @@ ShallowWrapper {
           component={[Function]}
           location={Object {}}
           onComplete={[Function]}
-          path="/edit/:protocol/form/:form?"
+          path={
+                    Array [
+                              "/edit/:protocol/form(s?)",
+                            ]
+          }
+/>,
+        <ShowRoute
+          component={[Function]}
+          location={Object {}}
+          onComplete={[Function]}
+          path={
+                    Array [
+                              "/edit/:protocol/form/:form",
+                            ]
+          }
 />,
         <ShowRoute
           component={[Function]}
@@ -222,7 +236,25 @@ ShallowWrapper {
           "component": [Function],
           "location": Object {},
           "onComplete": [Function],
-          "path": "/edit/:protocol/form/:form?",
+          "path": Array [
+            "/edit/:protocol/form(s?)",
+          ],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "component": [Function],
+          "location": Object {},
+          "onComplete": [Function],
+          "path": Array [
+            "/edit/:protocol/form/:form",
+          ],
         },
         "ref": null,
         "rendered": null,
@@ -321,7 +353,21 @@ ShallowWrapper {
             component={[Function]}
             location={Object {}}
             onComplete={[Function]}
-            path="/edit/:protocol/form/:form?"
+            path={
+                        Array [
+                                    "/edit/:protocol/form(s?)",
+                                  ]
+            }
+/>,
+          <ShowRoute
+            component={[Function]}
+            location={Object {}}
+            onComplete={[Function]}
+            path={
+                        Array [
+                                    "/edit/:protocol/form/:form",
+                                  ]
+            }
 />,
           <ShowRoute
             component={[Function]}
@@ -449,7 +495,25 @@ ShallowWrapper {
             "component": [Function],
             "location": Object {},
             "onComplete": [Function],
-            "path": "/edit/:protocol/form/:form?",
+            "path": Array [
+              "/edit/:protocol/form(s?)",
+            ],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "component": [Function],
+            "location": Object {},
+            "onComplete": [Function],
+            "path": Array [
+              "/edit/:protocol/form/:form",
+            ],
           },
           "ref": null,
           "rendered": null,

--- a/src/components/Views/__tests__/__snapshots__/Protocol.test.js.snap
+++ b/src/components/Views/__tests__/__snapshots__/Protocol.test.js.snap
@@ -41,8 +41,8 @@ ShallowWrapper {
       "children": Array [
         <Connect(withContext(Timeline))
           hasUnsavedChanges={false}
+          location={Object {}}
           onCreateStage={[Function]}
-          onEditSkipLogic={[Function]}
           onEditStage={[Function]}
           overview={Object {}}
           stages={
@@ -76,39 +76,25 @@ ShallowWrapper {
                     Save
           </Button>
 </ControlBar>,
-        <Connect(Draft(EditSkipLogic))
-          cancel={false}
-          onCancel={[Function]}
+        <ShowRoute
+          component={[Function]}
+          insertAtIndex={null}
+          location={Object {}}
           onComplete={[Function]}
-          show={false}
-          stageId={undefined}
-/>,
-        <Connect(EditStage)
-          cancel={false}
-          cardType={null}
-          onCancel={[Function]}
-          onComplete={[Function]}
-          show={false}
+          path="/edit/:protocol/stage/:id?"
+          type={null}
 />,
         <ShowRoute
           component={[Function]}
           location={Object {}}
           onComplete={[Function]}
-          path={
-                    Array [
-                              "/edit/:protocol/form(s?)",
-                            ]
-          }
+          path="/edit/:protocol/form(s?)"
 />,
         <ShowRoute
           component={[Function]}
           location={Object {}}
           onComplete={[Function]}
-          path={
-                    Array [
-                              "/edit/:protocol/form/:form",
-                            ]
-          }
+          path="/edit/:protocol/form/:form"
 />,
         <ShowRoute
           component={[Function]}
@@ -133,8 +119,8 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "hasUnsavedChanges": false,
+          "location": Object {},
           "onCreateStage": [Function],
-          "onEditSkipLogic": [Function],
           "onEditStage": [Function],
           "overview": Object {},
           "stages": Array [
@@ -201,28 +187,14 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
-          "cancel": false,
-          "onCancel": [Function],
+          "component": [Function],
+          "insertAtIndex": null,
+          "location": Object {},
           "onComplete": [Function],
-          "show": false,
-          "stageId": undefined,
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "cancel": false,
-          "cardType": null,
-          "onCancel": [Function],
-          "onComplete": [Function],
-          "show": false,
+          "path": "/edit/:protocol/stage/:id?",
+          "type": null,
         },
         "ref": null,
         "rendered": null,
@@ -236,9 +208,7 @@ ShallowWrapper {
           "component": [Function],
           "location": Object {},
           "onComplete": [Function],
-          "path": Array [
-            "/edit/:protocol/form(s?)",
-          ],
+          "path": "/edit/:protocol/form(s?)",
         },
         "ref": null,
         "rendered": null,
@@ -252,9 +222,7 @@ ShallowWrapper {
           "component": [Function],
           "location": Object {},
           "onComplete": [Function],
-          "path": Array [
-            "/edit/:protocol/form/:form",
-          ],
+          "path": "/edit/:protocol/form/:form",
         },
         "ref": null,
         "rendered": null,
@@ -300,8 +268,8 @@ ShallowWrapper {
         "children": Array [
           <Connect(withContext(Timeline))
             hasUnsavedChanges={false}
+            location={Object {}}
             onCreateStage={[Function]}
-            onEditSkipLogic={[Function]}
             onEditStage={[Function]}
             overview={Object {}}
             stages={
@@ -335,39 +303,25 @@ ShallowWrapper {
                         Save
             </Button>
 </ControlBar>,
-          <Connect(Draft(EditSkipLogic))
-            cancel={false}
-            onCancel={[Function]}
+          <ShowRoute
+            component={[Function]}
+            insertAtIndex={null}
+            location={Object {}}
             onComplete={[Function]}
-            show={false}
-            stageId={undefined}
-/>,
-          <Connect(EditStage)
-            cancel={false}
-            cardType={null}
-            onCancel={[Function]}
-            onComplete={[Function]}
-            show={false}
+            path="/edit/:protocol/stage/:id?"
+            type={null}
 />,
           <ShowRoute
             component={[Function]}
             location={Object {}}
             onComplete={[Function]}
-            path={
-                        Array [
-                                    "/edit/:protocol/form(s?)",
-                                  ]
-            }
+            path="/edit/:protocol/form(s?)"
 />,
           <ShowRoute
             component={[Function]}
             location={Object {}}
             onComplete={[Function]}
-            path={
-                        Array [
-                                    "/edit/:protocol/form/:form",
-                                  ]
-            }
+            path="/edit/:protocol/form/:form"
 />,
           <ShowRoute
             component={[Function]}
@@ -392,8 +346,8 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "hasUnsavedChanges": false,
+            "location": Object {},
             "onCreateStage": [Function],
-            "onEditSkipLogic": [Function],
             "onEditStage": [Function],
             "overview": Object {},
             "stages": Array [
@@ -460,28 +414,14 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
-            "cancel": false,
-            "onCancel": [Function],
+            "component": [Function],
+            "insertAtIndex": null,
+            "location": Object {},
             "onComplete": [Function],
-            "show": false,
-            "stageId": undefined,
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "cancel": false,
-            "cardType": null,
-            "onCancel": [Function],
-            "onComplete": [Function],
-            "show": false,
+            "path": "/edit/:protocol/stage/:id?",
+            "type": null,
           },
           "ref": null,
           "rendered": null,
@@ -495,9 +435,7 @@ ShallowWrapper {
             "component": [Function],
             "location": Object {},
             "onComplete": [Function],
-            "path": Array [
-              "/edit/:protocol/form(s?)",
-            ],
+            "path": "/edit/:protocol/form(s?)",
           },
           "ref": null,
           "rendered": null,
@@ -511,9 +449,7 @@ ShallowWrapper {
             "component": [Function],
             "location": Object {},
             "onComplete": [Function],
-            "path": Array [
-              "/edit/:protocol/form/:form",
-            ],
+            "path": "/edit/:protocol/form/:form",
           },
           "ref": null,
           "rendered": null,

--- a/src/components/Views/__tests__/__snapshots__/Protocol.test.js.snap
+++ b/src/components/Views/__tests__/__snapshots__/Protocol.test.js.snap
@@ -78,11 +78,9 @@ ShallowWrapper {
 </ControlBar>,
         <ShowRoute
           component={[Function]}
-          insertAtIndex={null}
           location={Object {}}
           onComplete={[Function]}
           path="/edit/:protocol/stage/:id?"
-          type={null}
 />,
         <ShowRoute
           component={[Function]}
@@ -94,7 +92,7 @@ ShallowWrapper {
           component={[Function]}
           location={Object {}}
           onComplete={[Function]}
-          path="/edit/:protocol/form/:form"
+          path="/edit/:protocol/form/:form?"
 />,
         <ShowRoute
           component={[Function]}
@@ -190,11 +188,9 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "component": [Function],
-          "insertAtIndex": null,
           "location": Object {},
           "onComplete": [Function],
           "path": "/edit/:protocol/stage/:id?",
-          "type": null,
         },
         "ref": null,
         "rendered": null,
@@ -222,7 +218,7 @@ ShallowWrapper {
           "component": [Function],
           "location": Object {},
           "onComplete": [Function],
-          "path": "/edit/:protocol/form/:form",
+          "path": "/edit/:protocol/form/:form?",
         },
         "ref": null,
         "rendered": null,
@@ -305,11 +301,9 @@ ShallowWrapper {
 </ControlBar>,
           <ShowRoute
             component={[Function]}
-            insertAtIndex={null}
             location={Object {}}
             onComplete={[Function]}
             path="/edit/:protocol/stage/:id?"
-            type={null}
 />,
           <ShowRoute
             component={[Function]}
@@ -321,7 +315,7 @@ ShallowWrapper {
             component={[Function]}
             location={Object {}}
             onComplete={[Function]}
-            path="/edit/:protocol/form/:form"
+            path="/edit/:protocol/form/:form?"
 />,
           <ShowRoute
             component={[Function]}
@@ -417,11 +411,9 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "component": [Function],
-            "insertAtIndex": null,
             "location": Object {},
             "onComplete": [Function],
             "path": "/edit/:protocol/stage/:id?",
-            "type": null,
           },
           "ref": null,
           "rendered": null,
@@ -449,7 +441,7 @@ ShallowWrapper {
             "component": [Function],
             "location": Object {},
             "onComplete": [Function],
-            "path": "/edit/:protocol/form/:form",
+            "path": "/edit/:protocol/form/:form?",
           },
           "ref": null,
           "rendered": null,

--- a/src/ducks/modules/protocol/file.js
+++ b/src/ducks/modules/protocol/file.js
@@ -6,6 +6,8 @@ import { getProtocol } from '../../../selectors/protocol';
 
 const OPEN_PROTOCOL = Symbol('PROTOCOL/OPEN');
 const PROTOCOL_LOADED = Symbol('PROTOCOL/LOADED');
+const LOAD_PROTOCOL_ERROR = Symbol('PROTOCOL/LOAD_ERROR');
+const OPEN_PROTOCOL_ERROR = Symbol('PROTOCOL/OPEN_ERROR');
 const SAVE_COMPLETE = Symbol('PROTOCOL/SAVE_COMPLETE');
 
 const isNetcanvasFile = fileName =>
@@ -99,6 +101,8 @@ const actionTypes = {
   SAVE_COMPLETE,
   OPEN_PROTOCOL,
   PROTOCOL_LOADED,
+  LOAD_PROTOCOL_ERROR,
+  OPEN_PROTOCOL_ERROR,
 };
 
 export {

--- a/src/ducks/modules/protocol/forms.js
+++ b/src/ducks/modules/protocol/forms.js
@@ -13,11 +13,10 @@ const formTemplate = {
   optionToAddAnother: false,
 };
 
-const formNameFromTitle = title => title.replace(/\W/g, '');
-
-function createForm(form) {
+function createForm(formName, form) {
   return {
     type: CREATE_FORM,
+    formName,
     form: { ...form, entity: 'node' },
   };
 }
@@ -44,7 +43,7 @@ export default function reducer(state = initialState, action = {}) {
 
       return {
         ...state,
-        [formNameFromTitle(form.title)]: form,
+        [action.formName]: form,
       };
     }
     case UPDATE_FORM:

--- a/src/ducks/modules/protocol/forms.js
+++ b/src/ducks/modules/protocol/forms.js
@@ -1,3 +1,5 @@
+import { omit } from 'lodash';
+
 const CREATE_FORM = 'CREATE_FORM';
 const UPDATE_FORM = 'UPDATE_FORM';
 const DELETE_FORM = 'DELETE_FORM';
@@ -28,9 +30,10 @@ function updateForm(formName, form) {
   };
 }
 
-function deleteForm() {
+function deleteForm(formName) {
   return {
     type: DELETE_FORM,
+    formName,
   };
 }
 
@@ -52,6 +55,8 @@ export default function reducer(state = initialState, action = {}) {
           ...action.form,
         },
       };
+    case DELETE_FORM:
+      return omit(state, [action.formName]);
     default:
       return state;
   }
@@ -64,6 +69,9 @@ const actionCreators = {
 };
 
 const actionTypes = {
+  CREATE_FORM,
+  UPDATE_FORM,
+  DELETE_FORM,
 };
 
 export {

--- a/src/ducks/modules/protocol/forms.js
+++ b/src/ducks/modules/protocol/forms.js
@@ -18,7 +18,7 @@ const formNameFromTitle = title => title.replace(/\W/g, '');
 function createForm(form) {
   return {
     type: CREATE_FORM,
-    form,
+    form: { ...form, entity: 'node' },
   };
 }
 
@@ -26,7 +26,7 @@ function updateForm(formName, form) {
   return {
     type: UPDATE_FORM,
     formName,
-    form,
+    form: { ...form, entity: 'node' },
   };
 }
 

--- a/src/other/protocols/template.json
+++ b/src/other/protocols/template.json
@@ -5,6 +5,7 @@
     "node": {
       "person": {
         "label": "Person",
+        "color": "node-color-seq-1",
         "displayVariable": "nickname",
         "iconVariant": "add-a-person",
         "variables": {
@@ -58,12 +59,15 @@
     },
     "edge": {
       "knows": {
+        "color": "edge-color-seq-1",
         "label": "Knows"
       },
       "likes": {
+        "color": "edge-color-seq-2",
         "label": "Likes"
       },
       "dislikes": {
+        "color": "edge-color-seq-3",
         "label": "Dislikes"
       }
     }

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { nth, find, get } from 'lodash';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { Protocol, Start, ViewTransitionRoute } from './components/Views';
 import ProtocolLoader from './components/ProtocolLoader';
 import tween from './behaviours/Tweened/tween';
@@ -70,20 +70,17 @@ class Routes extends Component {
           path="/edit/:protocol"
           render={props => <ProtocolLoader {...props} />}
         />
-        <Switch>
-          <ViewTransitionRoute
-            location={location}
-            path="/edit/:protocol"
-            component={Protocol}
-          />
-          <ViewTransitionRoute
-            location={location}
-            exact
-            path="/"
-            component={Start}
-          />
-          <Redirect to="/" />
-        </Switch>
+        <ViewTransitionRoute
+          location={location}
+          path="/edit/:protocol"
+          component={Protocol}
+        />
+        <ViewTransitionRoute
+          location={location}
+          exact
+          path="/"
+          component={Start}
+        />
       </React.Fragment>
     );
   }

--- a/src/styles/components/timeline/_overview.scss
+++ b/src/styles/components/timeline/_overview.scss
@@ -128,6 +128,11 @@
     }
   }
 
+  .button {
+    margin: unit(2) 0 0;
+    display: inline-block;
+  }
+
   &.tween-protocol {
     $transition-before: 500ms;
     $transition-after: 300ms;

--- a/src/styles/components/timeline/_overview.scss
+++ b/src/styles/components/timeline/_overview.scss
@@ -19,6 +19,21 @@
     flex: 1 1 100%;
   }
 
+  &__edge {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: unit(7);
+    width: unit(7);
+    height: unit(7);
+    margin: 0 0 unit(2) unit(2);
+    background-color: var(--architect-panel-shadow);
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+
   &__name {
     height: 9vh;
     display: flex;

--- a/src/styles/components/timeline/_stage.scss
+++ b/src/styles/components/timeline/_stage.scss
@@ -71,6 +71,7 @@ $component-name: timeline-stage;
   }
 
   &__screen {
+    display: block;
     width: $preview-width;
     padding-bottom: $preview-width * $preview-ratio;
     position: relative;

--- a/src/utils/CSSVariables.js
+++ b/src/utils/CSSVariables.js
@@ -4,7 +4,7 @@ const getCSSVariable = (variableName) => {
   const variable = getComputedStyle(document.body)
     .getPropertyValue(variableName)
     .trim();
-  if (isEmpty(variable)) { throw new Error(`CSS variable "${variableName}" not found.`); }
+  if (isEmpty(variable)) { console.log(`CSS variable "${variableName}" not found.`); }
   return variable;
 };
 

--- a/src/utils/CSSVariables.js
+++ b/src/utils/CSSVariables.js
@@ -4,6 +4,7 @@ const getCSSVariable = (variableName) => {
   const variable = getComputedStyle(document.body)
     .getPropertyValue(variableName)
     .trim();
+  // eslint-disable-next-line no-console
   if (isEmpty(variable)) { console.log(`CSS variable "${variableName}" not found.`); }
   return variable;
 };

--- a/src/utils/webShims/mockProtocol.json
+++ b/src/utils/webShims/mockProtocol.json
@@ -6,7 +6,7 @@
     "node": {
       "person": {
         "label": "Person",
-        "color": "color-neon-carrot",
+        "color": "node-color-seq-1",
         "displayVariable": "nickname",
         "iconVariant": "add-a-person",
         "variables": {
@@ -95,7 +95,7 @@
       },
       "venue": {
         "label": "Venue",
-        "color": "color-cerulean-blue",
+        "color": "node-color-seq-2",
         "iconVariant": "add-a-place",
         "variables": {
           "name": {
@@ -119,7 +119,7 @@
     "edge": {
       "friend": {
         "label": "Friend",
-        "color": "mustard",
+        "color": "edge-color-seq-1",
         "variables": {
           "contact_freq": {
             "label": "contact_freq",
@@ -137,7 +137,7 @@
       },
       "professional": {
         "label": "Professional",
-        "color": "kiwi",
+        "color": "edge-color-seq-2",
         "variables": {
         }
       }


### PR DESCRIPTION
Looking for feedback on this, re transitions.

This feature re-implements links to the form editor (which was removed when the variable registry was being developed).

I've been experimenting with the animation between these cards and the protocol, but haven't found anything satisfactory. The zoom animation is particularly awkward to get right so I've held off on adding that to the protocol overview, which I'm under the impression is likely to change.

Things to look at RE transitions:
- Card transitions:
  **in**
  i.e. `Protocol -> Variable registry`, or `Variable registry -> Node type`
  Currently this is a simple fade in.
  **out**
  i.e. `Variable registry -> Protocol`, or `Node type -> Variable registry`
  This is a wipe out, probably we should mirror the stage transition and use a fade for "save"
- Zoom transitions:
  For `Variable registry -> Node type`, this is the growing blot of color when clicking a node type *icon*.
  I'm not sure this makes sense for clicking on the node type *name*, and for consistency I'm inclined to omit it from both *name* and *icon.