### PR TITLE
Confirm and save before opening new protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12450,21 +12450,10 @@
             "dev": true
         },
         "path-to-regexp": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-            "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-            "dev": true,
-            "requires": {
-                "isarray": "0.0.1"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                }
-            }
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+            "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+            "dev": true
         },
         "path-type": {
             "version": "1.1.0",
@@ -14701,6 +14690,21 @@
                 "warning": "4.0.1"
             },
             "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+                    "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                },
                 "warning": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
@@ -18289,6 +18293,23 @@
             "requires": {
                 "path-to-regexp": "1.7.0",
                 "serviceworker-cache-polyfill": "4.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+                    "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                }
             }
         },
         "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "network-canvas-ui": "git+https://github.com/codaco/Network-Canvas-UI.git#1.13.3",
         "node-sass": "^4.9.2",
         "object-assign": "4.1.1",
+        "path-to-regexp": "^2.2.1",
         "postcss-flexbugs-fixes": "3.2.0",
         "postcss-loader": "^2.1.6",
         "promise": "7.1.1",

--- a/public/components/windowManager.js
+++ b/public/components/windowManager.js
@@ -53,6 +53,11 @@ function createWindow() {
 
     const mainWindow = new BrowserWindow(windowParameters);
 
+    mainWindow.webContents.on('new-window', (evt) => {
+      // A user may have tried to open a new window (shift|cmd-click); ignore action
+      evt.preventDefault();
+    });
+
     if (process.env.NODE_ENV === 'development') {
       mainWindow.openDevTools();
     }

--- a/src/ducks/modules/protocol/file.js
+++ b/src/ducks/modules/protocol/file.js
@@ -63,7 +63,7 @@ const saveProtocolThunk = () =>
     const activeProtocol = state.session.activeProtocol;
     const protocol = getProtocol(state);
 
-    saveProtocol(activeProtocol, protocol)
+    return saveProtocol(activeProtocol, protocol)
       .then(() => dispatch(saveComplete()));
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom';
 import initReactFastclick from 'react-fastclick';
 import { Provider } from 'react-redux';
 import { Router, Route } from 'react-router-dom';
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, remote } from 'electron';
+import pathToRegexp from 'path-to-regexp';
+import { get } from 'lodash';
 import './styles/main.scss';
 import memoryHistory from './history';
 import { store } from './ducks/store';
 import App from './components/App';
 import Routes from './routes';
 import ClipPaths from './components/ClipPaths';
+import { actionCreators as fileActionCreators } from './ducks/modules/protocol/file';
 
 initReactFastclick();
 
@@ -35,11 +38,35 @@ const startApp = () => {
 
 startApp();
 
-ipcRenderer.on('OPEN_FILE', (event, filePath) => {
-  const fileLocation = `/edit/${encodeURIComponent(filePath)}`;
-  const currentLocation = memoryHistory.location.pathname;
-  if (currentLocation === fileLocation) { return; }
-  memoryHistory.push(fileLocation);
+const getProtocol = (location) => {
+  const re = pathToRegexp('/edit/:protocol');
+  const matches = re.exec(location);
+  if (!matches) { return undefined; }
+  return get(matches, 1);
+};
+
+ipcRenderer.on('OPEN_FILE', (event, protocolPath) => {
+  const protocolLocation = `/edit/${encodeURIComponent(protocolPath)}`;
+  const currentProtocol = getProtocol(memoryHistory.location.pathname);
+  // If the protocol is already open, no op
+  if (encodeURIComponent(protocolPath) === currentProtocol) { return; }
+  // If no protocol is already open, just open it.
+  if (!currentProtocol) { memoryHistory.push(protocolLocation); return; }
+
+  remote.dialog.showMessageBox({
+    type: 'question',
+    message: `Attempting to open protocol "${protocolPath}"`,
+    buttons: ['Save and continue', 'Cancel'],
+  }, (response) => {
+    if (response !== 0) {
+      console.log(`Cancelled open of "${protocolPath}"`);
+      return;
+    }
+
+    console.log(`Save, then open "${protocolPath}"`);
+    store.dispatch(fileActionCreators.saveProtocol())
+      .then(() => memoryHistory.push(protocolLocation));
+  });
 });
 
 ipcRenderer.send('GET_ARGF');

--- a/src/index.js
+++ b/src/index.js
@@ -59,10 +59,12 @@ ipcRenderer.on('OPEN_FILE', (event, protocolPath) => {
     buttons: ['Save and continue', 'Cancel'],
   }, (response) => {
     if (response !== 0) {
+      // eslint-disable-next-line
       console.log(`Cancelled open of "${protocolPath}"`);
       return;
     }
 
+    // eslint-disable-next-line
     console.log(`Save, then open "${protocolPath}"`);
     store.dispatch(fileActionCreators.saveProtocol())
       .then(() => memoryHistory.push(protocolLocation));


### PR DESCRIPTION
This is a somewhat ugly fix for the issue of confirming & saving before switching to a new protocol #65. At the moment, this seems like the most straight-forward fix.

It makes me wonder if literally using routes to manage views is the correct approach, or whether we should moved this into the app state. Perhaps even using a pseudo location, and pseudo <Route /> components - this would allow us to make app navigation happen more coherently in actions/thunks.