### PR TITLE
Fix/form input types

### DIFF
--- a/src/components/FormEditor/FormEditor.js
+++ b/src/components/FormEditor/FormEditor.js
@@ -9,14 +9,20 @@ import Guidance from '../Guidance';
 import Disable from '../Disable';
 import NodeType from './NodeType';
 
-const allowedTypes = ['text', 'number', 'boolean'];
+const allowedTypes = ['text', 'number', 'boolean', 'ordinal', 'categorical'];
 
 const getInputsForType = (type) => {
   switch (type) {
+    case 'number':
+      return ['NumberInput'];
     case 'boolean':
-      return ['Checkbox'];
+      return ['Checkbox', 'Toggle', 'ToggleButton'];
+    case 'ordinal':
+      return ['RadioGroup'];
+    case 'categorical':
+      return ['CheckboxGroup', 'ToggleButtonGroup'];
     default:
-      return ['TextInput', 'SeamlessText'];
+      return ['TextInput'];
   }
 };
 

--- a/src/components/TypeEditor/Validations.js
+++ b/src/components/TypeEditor/Validations.js
@@ -44,6 +44,8 @@ const renderValidationOptions = ({ field, validationType }) => {
     case 'maxLength':
     case 'minValue':
     case 'maxValue':
+    case 'minSelected':
+    case 'maxSelected':
       return (
         <Field
           name={`${field}.value`}


### PR DESCRIPTION
Whitelist variable types listed here: https://github.com/codaco/Network-Canvas/wiki/Variable-Types for use in form editor, for types with valid inputs.

Add numeric input for ` minSelected`/`maxSelected` validation rules.

Resolves #176 
