### PR TITLE
Fix/sort order rules

### DIFF
--- a/src/components/Form/Fields/OrderBy.js
+++ b/src/components/Form/Fields/OrderBy.js
@@ -82,7 +82,7 @@ const Rule = compose(
             <option value="" disabled>&mdash; select direction &mdash;</option>
             {
               DIRECTIONS.map(([value, label]) => (
-                <option key={value}>{label}</option>
+                <option key={value} value={value}>{label}</option>
               ))
             }
           </Select>

--- a/src/components/Form/Fields/OrderBy.js
+++ b/src/components/Form/Fields/OrderBy.js
@@ -42,7 +42,7 @@ const Rule = compose(
   ({
     variables,
     disabledVariables,
-    rule: { variable, direction },
+    rule: { property, direction },
     sortIndex: index,
     handleChange,
     handleDelete,
@@ -56,8 +56,8 @@ const Rule = compose(
           <Select
             input={{
               onChange: event =>
-                handleChange(index, { variable: event.target.value }),
-              value: variable,
+                handleChange(index, { property: event.target.value }),
+              value: property,
             }}
           >
             <option value="" disabled>&mdash; select property &mdash;</option>
@@ -109,7 +109,7 @@ const Rules = compose(
           rules.map((rule, index) => (
             <Rule
               variables={variables}
-              disabledVariables={map(rules, 'variable')}
+              disabledVariables={map(rules, 'property')}
               handleChange={handleChange}
               handleDelete={handleDelete}
               index={index}
@@ -184,7 +184,7 @@ class OrderBy extends Component {
   handleAddNewRule = () => {
     const updatedRules = [
       ...this.value,
-      { variable: '', direction: '' },
+      { property: '', direction: '' },
     ];
     this.props.input.onChange(updatedRules);
   };


### PR DESCRIPTION
Use 'property' instead of 'variable' in sort order rules.

Use 'asc' / 'desc' values in sort order rules.

Resolves #170 