### PR TITLE
Fix/form changes not savable

### DIFF
--- a/src/components/Cards/EditForm.js
+++ b/src/components/Cards/EditForm.js
@@ -53,11 +53,10 @@ class EditForm extends PureComponent {
         key="save"
         size="small"
         onClick={this.submitForm}
-        color="white"
         iconPosition="right"
         disabled={this.props.hasErrors}
       >
-        Save
+        Continue
       </Button>
     );
 

--- a/src/components/Cards/EditType.js
+++ b/src/components/Cards/EditType.js
@@ -104,7 +104,7 @@ class EditType extends PureComponent {
         iconPosition="right"
         disabled={this.props.hasErrors}
       >
-        Save
+        Continue
       </Button>
     );
 

--- a/src/ducks/modules/session.js
+++ b/src/ducks/modules/session.js
@@ -1,6 +1,7 @@
 import { actionTypes as protocolFileActionTypes } from './protocol/file';
 import { actionTypes as protocolStageActionTypes } from './protocol/stages';
 import { actionTypes as protocolRegistryActionTypes } from './protocol/variableRegistry';
+import { actionTypes as formActionTypes } from './protocol/forms';
 import { actionTypes as protocolActionTypes } from './protocol/index';
 
 const initialState = {
@@ -39,6 +40,9 @@ export default function reducer(state = initialState, action = {}) {
     case protocolRegistryActionTypes.UPDATE_TYPE:
     case protocolRegistryActionTypes.CREATE_TYPE:
     case protocolRegistryActionTypes.DELETE_TYPE:
+    case formActionTypes.CREATE_FORM:
+    case formActionTypes.UPDATE_FORM:
+    case formActionTypes.DELETE_FORM:
     case protocolActionTypes.UPDATE_OPTIONS:
       return {
         ...state,


### PR DESCRIPTION
Makes form edit actions to savable actions.

Changes labels on edit from from 'save' to 'continue'.

Resolves #167