### PR TITLE
Feature/focus guidance

### DIFF
--- a/src/components/Guidance.js
+++ b/src/components/Guidance.js
@@ -4,62 +4,45 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { actionCreators as guidedActionCreators } from '../ducks/modules/guidance';
 
-const MOUSE = 'MOUSE';
-const FOCUS = 'FOCUS';
-
 class Guided extends Component {
   static propTypes = {
     contentId: PropTypes.string.isRequired,
     setGuidance: PropTypes.func.isRequired,
     unsetGuidance: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
-    interaction: PropTypes.oneOf([
-      MOUSE,
-      FOCUS,
-    ]),
+    focus: PropTypes.bool,
   };
 
   static defaultProps = {
-    interaction: MOUSE,
+    focus: false,
   };
 
-  get interactionHandlers() {
-    switch (this.props.interaction) {
-      case MOUSE:
-        return {
-          onMouseEnter: this.handleMouseEnter,
-          onMouseLeave: this.handleMouseLeave,
-        };
-      case FOCUS:
-        return {
-          onFocus: this.handleFocus,
-          onBlur: this.handleBlur,
-        };
-      default:
-        return {};
+  interactionHandlers() {
+    if (this.props.focus) {
+      return {
+        onFocus: this.handleSet,
+        onBlur: this.handleUnset,
+      };
     }
+
+    return {
+      onMouseEnter: this.handleSet,
+      onMouseLeave: this.handleUnset,
+    };
   }
 
-  handleMouseEnter = () => {
-    this.props.setGuidance(this.props.contentId);
+  handleSet = () => {
+    this.props.setGuidance(this.props.contentId, this.props.focus ? 'focus' : 'mouse');
   }
 
-  handleMouseLeave = () => {
-    this.props.unsetGuidance();
-  }
-
-  handleFocus = () => {
-    this.props.setGuidance(this.props.contentId);
-  }
-
-  handleBlur = () => {
-    this.props.unsetGuidance();
+  handleUnset = () => {
+    this.props.unsetGuidance(this.props.focus ? 'focus' : 'mouse');
   }
 
   render() {
     return React.cloneElement(
       this.props.children,
-      this.interactionHandlers,
+      this.interactionHandlers(),
     );
   }
 }

--- a/src/components/Guidance.js
+++ b/src/components/Guidance.js
@@ -11,7 +11,7 @@ class Guided extends Component {
   static propTypes = {
     contentId: PropTypes.string.isRequired,
     setGuidance: PropTypes.func.isRequired,
-    clearGuidance: PropTypes.func.isRequired,
+    unsetGuidance: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
     interaction: PropTypes.oneOf([
       MOUSE,
@@ -45,7 +45,7 @@ class Guided extends Component {
   }
 
   handleMouseLeave = () => {
-    this.props.clearGuidance();
+    this.props.unsetGuidance();
   }
 
   handleFocus = () => {
@@ -53,7 +53,7 @@ class Guided extends Component {
   }
 
   handleBlur = () => {
-    this.props.clearGuidance();
+    this.props.unsetGuidance();
   }
 
   render() {
@@ -66,7 +66,7 @@ class Guided extends Component {
 
 const mapDispatchToProps = dispatch => ({
   setGuidance: bindActionCreators(guidedActionCreators.setGuidance, dispatch),
-  clearGuidance: bindActionCreators(guidedActionCreators.resetGuidance, dispatch),
+  unsetGuidance: bindActionCreators(guidedActionCreators.unsetGuidance, dispatch),
 });
 
 export { Guided };

--- a/src/components/Guidance.js
+++ b/src/components/Guidance.js
@@ -4,13 +4,41 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { actionCreators as guidedActionCreators } from '../ducks/modules/guidance';
 
+const MOUSE = 'MOUSE';
+const FOCUS = 'FOCUS';
+
 class Guided extends Component {
   static propTypes = {
     contentId: PropTypes.string.isRequired,
     setGuidance: PropTypes.func.isRequired,
     clearGuidance: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
+    interaction: PropTypes.oneOf([
+      MOUSE,
+      FOCUS,
+    ]),
   };
+
+  static defaultProps = {
+    interaction: MOUSE,
+  };
+
+  get interactionHandlers() {
+    switch (this.props.interaction) {
+      case MOUSE:
+        return {
+          onMouseEnter: this.handleMouseEnter,
+          onMouseLeave: this.handleMouseLeave,
+        };
+      case FOCUS:
+        return {
+          onFocus: this.handleFocus,
+          onBlur: this.handleBlur,
+        };
+      default:
+        return {};
+    }
+  }
 
   handleMouseEnter = () => {
     this.props.setGuidance(this.props.contentId);
@@ -20,13 +48,18 @@ class Guided extends Component {
     this.props.clearGuidance();
   }
 
+  handleFocus = () => {
+    this.props.setGuidance(this.props.contentId);
+  }
+
+  handleBlur = () => {
+    this.props.clearGuidance();
+  }
+
   render() {
     return React.cloneElement(
       this.props.children,
-      {
-        onMouseEnter: this.handleMouseEnter,
-        onMouseLeave: this.handleMouseLeave,
-      },
+      this.interactionHandlers,
     );
   }
 }

--- a/src/ducks/modules/__tests__/guidance.test.js
+++ b/src/ducks/modules/__tests__/guidance.test.js
@@ -1,0 +1,92 @@
+/* eslint-env jest */
+
+import { flow } from 'lodash';
+import reducer, { actionCreators } from '../guidance';
+
+describe('guidance reducer', () => {
+  it('has an initial state', () => {
+    expect(reducer(undefined))
+      .toEqual({
+        history: [],
+        id: null,
+      });
+  });
+
+  describe('setGuidance', () => {
+    it('records guidance with setGuidance', () => {
+      expect(reducer(undefined, actionCreators.setGuidance('foo', 'bar')))
+        .toEqual({
+          history: [{
+            name: 'bar',
+            id: 'foo',
+          }],
+          id: 'foo',
+        });
+    });
+
+    it('each successive call is added to history', () => {
+      const result = flow(
+        state => reducer(state, actionCreators.setGuidance('foo', 'bar')),
+        state => reducer(state, actionCreators.setGuidance('bazz', 'buzz')),
+      )(undefined);
+
+      expect(result)
+        .toEqual({
+          history: [
+            { id: 'foo', name: 'bar' },
+            { id: 'bazz', name: 'buzz' },
+          ],
+          id: 'bazz',
+        });
+    });
+  });
+
+  describe('unsetGuidance', () => {
+    it('it removes item from history and sets id to the last item in history', () => {
+      const result = flow(
+        state => reducer(state, actionCreators.setGuidance('foo', 'bar')),
+        state => reducer(state, actionCreators.setGuidance('bazz', 'buzz')),
+        state => reducer(state, actionCreators.unsetGuidance('buzz')),
+      )(undefined);
+
+      expect(result)
+        .toEqual({
+          history: [
+            { id: 'foo', name: 'bar' },
+          ],
+          id: 'foo',
+        });
+    });
+
+    it('it will remove intermediate history without changing id', () => {
+      const result = flow(
+        state => reducer(state, actionCreators.setGuidance('foo', 'bar')),
+        state => reducer(state, actionCreators.setGuidance('bazz', 'buzz')),
+        state => reducer(state, actionCreators.setGuidance('fizz', 'pop')),
+        state => reducer(state, actionCreators.unsetGuidance('buzz')),
+      )(undefined);
+
+      expect(result)
+        .toEqual({
+          history: [
+            { id: 'foo', name: 'bar' },
+            { id: 'fizz', name: 'pop' },
+          ],
+          id: 'fizz',
+        });
+    });
+
+    it('it will remove last item and reset id to null', () => {
+      const result = flow(
+        state => reducer(state, actionCreators.setGuidance('foo', 'bar')),
+        state => reducer(state, actionCreators.unsetGuidance('bar')),
+      )(undefined);
+
+      expect(result)
+        .toEqual({
+          history: [],
+          id: null,
+        });
+    });
+  });
+});

--- a/src/ducks/modules/__tests__/guidance.test.js
+++ b/src/ducks/modules/__tests__/guidance.test.js
@@ -39,6 +39,21 @@ describe('guidance reducer', () => {
           id: 'bazz',
         });
     });
+
+    it('duplicate names are replaced', () => {
+      const result = flow(
+        state => reducer(state, actionCreators.setGuidance('foo', 'bar')),
+        state => reducer(state, actionCreators.setGuidance('bazz', 'bar')),
+      )(undefined);
+
+      expect(result)
+        .toEqual({
+          history: [
+            { id: 'bazz', name: 'bar' },
+          ],
+          id: 'bazz',
+        });
+    });
   });
 
   describe('unsetGuidance', () => {

--- a/src/ducks/modules/guidance.js
+++ b/src/ducks/modules/guidance.js
@@ -3,28 +3,34 @@ const RESET_GUIDANCE = Symbol('PROTOCOL/RESET_GUIDANCE');
 
 const initialState = {
   id: null,
+  locked: false,
 };
 
-const setGuidance = id =>
+const setGuidance = (id, lock = false) =>
   ({
     type: SET_GUIDANCE,
     id,
+    lock,
   });
 
-const resetGuidance = () =>
+const resetGuidance = (unlock = false) =>
   ({
     type: RESET_GUIDANCE,
+    unlock,
   });
 
 
 function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case SET_GUIDANCE:
+      if (state.locked && !action.lock) { return state; }
       return {
         ...state,
         id: action.id,
+        locked: action.lock,
       };
     case RESET_GUIDANCE:
+      if (state.locked && !action.unlock) { return state; }
       return { ...initialState };
     default:
       return state;

--- a/src/ducks/modules/guidance.js
+++ b/src/ducks/modules/guidance.js
@@ -23,15 +23,17 @@ const unsetGuidance = (name = 'default') =>
 
 function reducer(state = initialState, action = {}) {
   switch (action.type) {
-    case SET_GUIDANCE:
+    case SET_GUIDANCE: {
+      const history = state.history.filter(({ name }) => name !== action.name);
       return {
         ...state,
         history: [
-          ...state.history,
+          ...history,
           { name: action.name, id: action.id },
         ],
         id: action.id,
       };
+    }
     case UNSET_GUIDANCE: {
       const history = state.history.filter(({ name }) => name !== action.name);
 

--- a/src/ducks/modules/guidance.js
+++ b/src/ducks/modules/guidance.js
@@ -1,37 +1,46 @@
+import { last } from 'lodash';
+
 const SET_GUIDANCE = Symbol('PROTOCOL/SET_GUIDANCE');
-const RESET_GUIDANCE = Symbol('PROTOCOL/RESET_GUIDANCE');
+const UNSET_GUIDANCE = Symbol('PROTOCOL/UNSET_GUIDANCE');
 
 const initialState = {
   id: null,
-  locked: false,
+  history: [],
 };
 
-const setGuidance = (id, lock = false) =>
+const setGuidance = (id, name = 'default') =>
   ({
     type: SET_GUIDANCE,
     id,
-    lock,
+    name,
   });
 
-const resetGuidance = (unlock = false) =>
+const unsetGuidance = (name = 'default') =>
   ({
-    type: RESET_GUIDANCE,
-    unlock,
+    type: UNSET_GUIDANCE,
+    name,
   });
-
 
 function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case SET_GUIDANCE:
-      if (state.locked && !action.lock) { return state; }
       return {
         ...state,
+        history: [
+          ...state.history,
+          { name: action.name, id: action.id },
+        ],
         id: action.id,
-        locked: action.lock,
       };
-    case RESET_GUIDANCE:
-      if (state.locked && !action.unlock) { return state; }
-      return { ...initialState };
+    case UNSET_GUIDANCE: {
+      const history = state.history.filter(({ name }) => name !== action.name);
+
+      return {
+        ...state,
+        history,
+        id: history.length > 0 ? last(history).id : null,
+      };
+    }
     default:
       return state;
   }
@@ -39,12 +48,12 @@ function reducer(state = initialState, action = {}) {
 
 const actionCreators = {
   setGuidance,
-  resetGuidance,
+  unsetGuidance,
 };
 
 const actionTypes = {
   SET_GUIDANCE,
-  RESET_GUIDANCE,
+  UNSET_GUIDANCE,
 };
 
 export {

--- a/src/ducks/store.js
+++ b/src/ducks/store.js
@@ -8,7 +8,7 @@ import { rootReducer } from './modules/root';
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['form', 'protocol', 'session'],
+  blacklist: ['form', 'protocol', 'session', 'guidance'],
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -23,13 +23,6 @@ export default {
       </p>
     </Fragment>
   ),
-  'guidance.editor.title.field': (
-    <Fragment>
-      <p>
-        This explanation is specific to the field!
-      </p>
-    </Fragment>
-  ),
   'guidance.editor.content_items': (
     <Fragment>
       <h3>Content Items help</h3>

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -23,6 +23,13 @@ export default {
       </p>
     </Fragment>
   ),
+  'guidance.editor.title.field': (
+    <Fragment>
+      <p>
+        This explanation is specific to the field!
+      </p>
+    </Fragment>
+  ),
   'guidance.editor.content_items': (
     <Fragment>
       <h3>Content Items help</h3>


### PR DESCRIPTION
Adds a 'focus' mode to the`<Guidance />` component.

This also changes the guidance reducer to include history - so that focus and mouseover guidance interactions can switch back and forth without needing to refocus and element.

Resolves #114