### PR TITLE
Add validation to ContentGrid items

### DIFF
--- a/src/components/Form/Fields/Audio.js
+++ b/src/components/Form/Fields/Audio.js
@@ -5,11 +5,11 @@ import { Audio } from '../../Assets';
 const AudioInput = props => (
   <File
     accept="audio/*"
-    completeClassName="form-fields-audio--complete"
+    className="form-fields-audio"
     {...props}
   >
     { url => (
-      <div className="form-fields-audio">
+      <div className="form-fields-audio__preview">
         <Audio url={url} controls />
       </div>
     ) }

--- a/src/components/Form/Fields/File.js
+++ b/src/components/Form/Fields/File.js
@@ -11,20 +11,19 @@ import { actionCreators as assetActions } from '../../../ducks/modules/protocol/
 class FileInput extends PureComponent {
   static propTypes = {
     importAsset: PropTypes.func.isRequired,
-    className: PropTypes.string,
-    completeClassName: PropTypes.string,
     accept: PropTypes.string,
     children: PropTypes.func,
     label: PropTypes.string,
+    className: PropTypes.string,
     ...fieldPropTypes,
   };
 
   static defaultProps = {
     value: '',
-    className: 'form-fields-file',
-    completeClassName: 'form-fields-file--complete',
+    meta: { invalid: false, error: null, touched: false },
     accept: '',
     label: '',
+    className: '',
     children: value => value,
   };
 
@@ -44,14 +43,24 @@ class FileInput extends PureComponent {
   render() {
     const {
       input: { value },
+      meta: { touched, invalid, error },
       accept,
       label,
       className,
-      completeClassName,
     } = this.props;
 
+    const fieldClasses = cx(
+      'form-fields-file',
+      className,
+      'form-field-container',
+      {
+        'form-fields-mode--has-error': touched && invalid,
+        'form-fields-file--complete': !!value,
+      },
+    );
+
     return (
-      <div className={cx(className, 'form-field-container', { [completeClassName]: !!value })}>
+      <div className={fieldClasses}>
         { label &&
           <h4 className="form-fields-file__label">{label}</h4>
         }
@@ -72,6 +81,7 @@ class FileInput extends PureComponent {
             </div>
           }
         </div>
+        { touched && invalid && <p className="form-fields-mode__error">{error}</p> }
       </div>
     );
   }

--- a/src/components/Form/Fields/Mode.js
+++ b/src/components/Form/Fields/Mode.js
@@ -7,6 +7,7 @@ class Mode extends PureComponent {
   static propTypes = {
     options: PropTypes.array,
     label: PropTypes.string,
+    meta: PropTypes.object,
     className: PropTypes.string,
     input: PropTypes.object.isRequired,
   };
@@ -14,6 +15,7 @@ class Mode extends PureComponent {
   static defaultProps = {
     className: null,
     label: null,
+    meta: { invalid: false, error: null, touched: false },
     options: [],
     disabled: false,
   };
@@ -53,12 +55,16 @@ class Mode extends PureComponent {
       options,
       className,
       label,
+      meta: { touched, invalid, error },
     } = this.props;
 
     const classNames = cx(
       'form-field-container',
       'form-fields-mode',
       className,
+      {
+        'form-fields-mode--has-error': touched && invalid,
+      },
     );
 
     return (
@@ -66,11 +72,10 @@ class Mode extends PureComponent {
         { label &&
           <h4 className="form-fields-mode__label">{label}</h4>
         }
-        <div>
-          <div className="form-fields-mode__options">
-            { options.map(this.renderMode) }
-          </div>
+        <div className="form-fields-mode__options">
+          { options.map(this.renderMode) }
         </div>
+        { touched && invalid && <p className="form-fields-mode__error">{error}</p> }
       </div>
     );
   }

--- a/src/components/StageEditor/sections/ContentGrid/Item.js
+++ b/src/components/StageEditor/sections/ContentGrid/Item.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { get } from 'lodash';
 import ItemPreview from './ItemPreview';
 import ItemChooser from './ItemChooser';
 import ItemEditor from './ItemEditor';
@@ -10,10 +11,11 @@ import { sizes } from './sizes';
 class Item extends Component {
   static propTypes = {
     fieldId: PropTypes.string.isRequired,
-    editing: PropTypes.string,
+    editing: PropTypes.object,
     onToggleItemEdit: PropTypes.func.isRequired,
     handleDelete: PropTypes.func.isRequired,
     onChooseItemType: PropTypes.func.isRequired,
+    error: PropTypes.object,
     item: PropTypes.shape({
       content: PropTypes.string,
       type: PropTypes.string,
@@ -23,6 +25,7 @@ class Item extends Component {
   };
 
   static defaultProps = {
+    error: undefined,
     editing: null,
     item: {
       content: null,
@@ -41,13 +44,18 @@ class Item extends Component {
   }
 
   get isEditing() {
-    return this.item.id === this.props.editing;
+    return get(this.props.editing, this.item.id);
+  }
+
+  get hasError() {
+    return this.props.error;
   }
 
   handleChooseItemType = type =>
     this.props.onChooseItemType(this.props.fieldId, type);
 
   handleToggleItemEdit = () => {
+    if (this.hasError) { return; }
     this.props.onToggleItemEdit(this.item.id);
   }
 
@@ -60,7 +68,7 @@ class Item extends Component {
 
     const variableClasses = cx(
       'content-grid-item',
-      { 'content-grid-item--edit': this.isEditing },
+      { 'content-grid-item--edit': this.isEditing || this.hasError },
       { 'content-grid-item--new': this.isNew },
     );
 
@@ -91,6 +99,7 @@ class Item extends Component {
             type={this.item.type}
             size={this.item.size}
             spareCapacity={spareCapacity}
+            error={this.props.error}
             onComplete={this.handleToggleItemEdit}
           />
         </div>
@@ -99,8 +108,9 @@ class Item extends Component {
   }
 }
 
-const mapStateToProps = (state, { fieldId, form }) => ({
+const mapStateToProps = (state, { fieldId, form, errors }) => ({
   item: form.getValues(state, `${fieldId}`),
+  error: get(errors, fieldId),
 });
 
 export { Item };

--- a/src/components/StageEditor/sections/ContentGrid/ItemEditor.js
+++ b/src/components/StageEditor/sections/ContentGrid/ItemEditor.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { get } from 'lodash';
-import { Field } from 'redux-form';
+import ValidatedField from '../../../Form/ValidatedField';
 import { Markdown, Image, Audio, Video, Mode } from '../../../Form/Fields';
 import { Button } from '../../../../ui/components';
+import { getFieldId } from '../../../../utils/issues';
 import { units, sizes } from './sizes';
 
 const sizeOptions = [
@@ -49,26 +50,31 @@ class ItemEditor extends Component {
   }
 
   render() {
-    const { name, show, onComplete } = this.props;
+    const { name, show, onComplete, error, type } = this.props;
 
     return (
       <div className={cx('content-grid-editor', { 'content-grid-editor--show': show })}>
         <div className="content-grid-editor__content" onClick={e => e.stopPropagation()}>
-          <Field
+          <div id={getFieldId(`${name}.size`)} data-name="Display size" />
+          <ValidatedField
             component={Mode}
             name={`${name}.size`}
             label="Display size"
             options={this.options}
+            validation={{ required: true }}
           />
-          <Field
+          <div id={getFieldId(`${name}.content`)} data-name={`${type} content`} />
+          <ValidatedField
             label="Content"
             name={`${name}.content`}
             component={this.inputComponent}
+            validation={{ required: true }}
           />
           <Button
             type="button"
             size="small"
             onClick={onComplete}
+            disabled={error}
           >Done</Button>
         </div>
       </div>
@@ -84,6 +90,7 @@ ItemEditor.propTypes = {
   show: PropTypes.bool,
   spareCapacity: PropTypes.number,
   onComplete: PropTypes.func.isRequired,
+  error: PropTypes.object,
 };
 
 ItemEditor.defaultProps = {
@@ -92,6 +99,7 @@ ItemEditor.defaultProps = {
   type: null,
   size: null,
   spareCapacity: 0,
+  error: undefined,
 };
 
 export { ItemEditor };

--- a/src/components/StageEditor/sections/ContentGrid/_tests__/ContentGrid.test.js
+++ b/src/components/StageEditor/sections/ContentGrid/_tests__/ContentGrid.test.js
@@ -9,6 +9,7 @@ const mockProps = {
   spareCapacity: 0,
   setInputType: () => {},
   form: {},
+  errors: {},
 };
 
 describe('<ContentGrid />', () => {
@@ -31,16 +32,16 @@ describe('<ContentGrid />', () => {
     component.find('NewButton').simulate('click');
 
     expect(createNewItemHandler.mock.calls.length).toBe(1);
-    expect(component.state('editing')).toBe('foo');
+    expect(component.state('editing')).toEqual({ foo: true });
   });
 
   it('toggle item edit changes state', () => {
     const component = shallow(<ContentGrid {...mockProps} />);
 
     component.instance().handleToggleItemEdit('bar');
-    expect(component.state('editing')).toBe('bar');
+    expect(component.state('editing')).toEqual({ bar: true });
 
     component.instance().handleToggleItemEdit('bar');
-    expect(component.state('editing')).toBe(null);
+    expect(component.state('editing')).toEqual({ bar: false });
   });
 });

--- a/src/components/StageEditor/sections/ContentGrid/_tests__/Item.test.js
+++ b/src/components/StageEditor/sections/ContentGrid/_tests__/Item.test.js
@@ -28,7 +28,7 @@ describe('<Item />', () => {
 
   it('shows edit/preview correctly', () => {
     const componentWithType = shallow(<Item {...mockProps} item={{ type: 'foo' }} />);
-    const componentWithEditor = shallow(<Item {...mockProps} editing="foo" item={{ id: 'foo' }} />);
+    const componentWithEditor = shallow(<Item {...mockProps} editing={{ foo: true }} item={{ id: 'foo' }} />);
     const componentWithPreview = shallow(<Item {...mockProps} editing={null} item={{ id: 'foo' }} />);
 
     expect(componentWithType.find('ItemPreview').exists()).toBe(true);

--- a/src/components/StageEditor/sections/ContentGrid/_tests__/__snapshots__/Item.test.js.snap
+++ b/src/components/StageEditor/sections/ContentGrid/_tests__/__snapshots__/Item.test.js.snap
@@ -99,6 +99,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "content": null,
+              "error": undefined,
               "name": "foo",
               "onComplete": [Function],
               "show": false,
@@ -190,6 +191,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "content": null,
+                "error": undefined,
                 "name": "foo",
                 "onComplete": [Function],
                 "show": false,

--- a/src/styles/components/form/_fields.scss
+++ b/src/styles/components/form/_fields.scss
@@ -5,6 +5,15 @@
     display: block;
     margin: 0 0 unit(1);
   }
+
+  &__error {
+    opacity: 0;
+    max-height: 0;
+    color: var(--error);
+    margin: unit(1) 0 0;
+    transition: opacity var(--animation-easing) var(--animation-duration-standard),
+    max-height var(--animation-easing) var(--animation-duration-standard);
+  }
 }
 
 @import './fields/contexts';

--- a/src/styles/components/form/fields/_audio.scss
+++ b/src/styles/components/form/fields/_audio.scss
@@ -1,16 +1,18 @@
 $component-name: form-fields-audio;
 
 .#{$component-name} {
-  background: var(--architect-panel-background);
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
+  &__preview {
+    background: var(--architect-panel-background);
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
 
-  audio {
-    width: 100%;
+    audio {
+      width: 100%;
+    }
   }
 
-  &--complete {
+  &.form-fields-file--complete {
     .form-dropzone {
       position: static !important; // sass-lint:disable-line no-important
       transform: translateY(0);

--- a/src/styles/components/form/fields/_file.scss
+++ b/src/styles/components/form/fields/_file.scss
@@ -12,6 +12,7 @@
   &__file {
     position: relative;
     min-height: 100px;
+    overflow: hidden;
 
     .form-dropzone {
       min-height: 150px;
@@ -41,5 +42,10 @@
     }
   }
 
-
+  &--has-error {
+    .form-fields-file__error {
+      opacity: 1;
+      max-height: 50px;
+    }
+  }
 }

--- a/src/styles/components/form/fields/_mode.scss
+++ b/src/styles/components/form/fields/_mode.scss
@@ -35,4 +35,11 @@
       cursor: not-allowed;
     }
   }
+
+  &--has-error {
+    .form-fields-mode__error {
+      opacity: 1;
+      max-height: 50px;
+    }
+  }
 }


### PR DESCRIPTION
- Can edit multiple items at once
- Adds error functionality to <Mode /> and <File />
- Disables 'done' button for editing item, if item isn't valid
- Keeps items open if they have errors

Resolves https://github.com/codaco/Architect/issues/234