### PR TITLE
Feature/delete type side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "dist:win": "npm run build && electron-builder -w --publish=always",
         "dist:all": "npm run build && electron-builder -mlw --publish=always",
         "bump": "sh scripts/bump",
-        "preflight": "[[ -z $(git status --porcelain) ]] && npm run lint && npm run lint:sass -- --max-warnings 0 && npm test -- --coverage"
+        "preflight": "npm run lint && npm run lint:sass -- --max-warnings 0 && npm test -- --coverage"
     },
     "repository": {
         "type": "git"

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -72,16 +72,15 @@ class VariableRegistry extends Component {
       '',
     );
 
-    if (usage.length > 0) {
-      // eslint-disable-next-line no-alert
-      if (!confirm(`
-Because a number of other objects depend on this type, they will also be removed:
-${deletedObjects}
-      `)) { return; }
-    }
+    const confirmMessage = `Are you sure you want to delete "${type} ${entity}" ${
+      usage.length > 0 ?
+        `\n\nBecause a number of other objects depend on this type, they will also be removed: \n${deletedObjects}` :
+        ''
+    }`;
 
     // eslint-disable-next-line no-alert
-    if (!confirm(`Are you sure you want to delete "${type} ${entity}"?`)) { return; }
+    if (!confirm(confirmMessage)) { return; }
+
     this.props.deleteType(entity, type, true);
   };
 

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -220,6 +220,8 @@ VariableRegistry.propTypes = {
   protocolPath: PropTypes.string,
   onComplete: PropTypes.func,
   deleteType: PropTypes.func.isRequired,
+  getDeleteImpact: PropTypes.func.isRequired,
+  getObjectLabel: PropTypes.func.isRequired,
 };
 
 VariableRegistry.defaultProps = {

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -15,7 +15,7 @@ import { getProtocol } from '../../selectors/protocol';
 import { makeGetUsageForType } from '../../selectors/variableRegistry';
 import { actionCreators as variableRegistryActions } from '../../ducks/modules/protocol/variableRegistry';
 
-const Type = ({ label, link, children, handleDelete }) => (
+const Type = ({ label, link, children, usage, handleDelete }) => (
   <div className="list__item">
     <div className="list__attribute list__attribute--icon">
       <Link to={link}>
@@ -28,6 +28,7 @@ const Type = ({ label, link, children, handleDelete }) => (
           {label}
         </Link>
       </h3>
+      { usage.length === 0 && <div className="list__tag">unused</div> }
     </div>
     <div className="list__attribute list__attribute--options">
       <Button size="small" color="neon-coral" onClick={handleDelete}>
@@ -40,8 +41,13 @@ const Type = ({ label, link, children, handleDelete }) => (
 Type.propTypes = {
   label: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
+  usage: PropTypes.array,
   handleDelete: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
+};
+
+Type.defaultProps = {
+  usage: [],
 };
 
 /**
@@ -83,6 +89,7 @@ ${deletedObjects}
 
   renderNode = (node, key) => {
     const nodeColor = get(node, 'color', '');
+    const usage = this.props.getUsageForType('node', key);
 
     return (
       <Wipe key={key}>
@@ -90,6 +97,7 @@ ${deletedObjects}
           link={`${this.props.protocolPath}/registry/node/${key}`}
           label={node.label}
           handleDelete={() => this.handleDelete('node', key)}
+          usage={usage}
         >
           <Node label="" color={nodeColor} />
         </Type>
@@ -99,6 +107,7 @@ ${deletedObjects}
 
   renderEdge = (edge, key) => {
     const edgeColor = `var(--${get(edge, 'color', '')})`;
+    const usage = this.props.getUsageForType('edge', key);
 
     return (
       <Wipe key={key}>
@@ -106,6 +115,7 @@ ${deletedObjects}
           link={`${this.props.protocolPath}/registry/edge/${key}`}
           label={edge.label}
           handleDelete={() => this.handleDelete('edge', key)}
+          usage={usage}
         >
           <EdgeIcon color={edgeColor} />
         </Type>

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -76,7 +76,7 @@ ${deletedObjects}
 
     // eslint-disable-next-line no-alert
     if (!confirm(`Are you sure you want to delete "${type} ${entity}"?`)) { return; }
-    this.props.deleteTypeAndRelatedObjects(entity, type);
+    this.props.deleteType(entity, type, true);
   };
 
   handleCancel = this.props.onComplete;
@@ -214,7 +214,7 @@ VariableRegistry.propTypes = {
   getUsageForType: PropTypes.func.isRequired,
   protocolPath: PropTypes.string,
   onComplete: PropTypes.func,
-  deleteTypeAndRelatedObjects: PropTypes.func.isRequired,
+  deleteType: PropTypes.func.isRequired,
 };
 
 VariableRegistry.defaultProps = {
@@ -241,10 +241,7 @@ const mapStateToProps = (state, props) => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  deleteTypeAndRelatedObjects: bindActionCreators(
-    variableRegistryActions.deleteTypeAndRelatedObjects,
-    dispatch,
-  ),
+  deleteType: bindActionCreators(variableRegistryActions.deleteType, dispatch),
 });
 
 export { VariableRegistry };

--- a/src/components/Cards/VariableRegistry.js
+++ b/src/components/Cards/VariableRegistry.js
@@ -63,7 +63,7 @@ class VariableRegistry extends Component {
           `${memo}\n    stage prompt: ${owner.stageId}: ${owner.promptId}` :
           `${memo}\n    ${owner.type}: ${owner.id}`
       ),
-      ''
+      '',
     );
 
     if (usage.length > 0) {

--- a/src/components/Cards/__tests__/VariableRegistry.test.js
+++ b/src/components/Cards/__tests__/VariableRegistry.test.js
@@ -12,6 +12,8 @@ const mockProps = {
   getUsageForType: () => {},
   deleteType: () => {},
   protocolPath: '',
+  getDeleteImpact: () => {},
+  getObjectLabel: () => {},
 };
 
 describe('<VariableRegistry />', () => {

--- a/src/components/Cards/__tests__/VariableRegistry.test.js
+++ b/src/components/Cards/__tests__/VariableRegistry.test.js
@@ -9,7 +9,8 @@ const mockProps = {
     node: {},
     edge: {},
   },
-  deleteType: () => {},
+  getUsageForType: () => {},
+  deleteTypeAndRelatedObjects: () => {},
   protocolPath: '',
 };
 

--- a/src/components/Cards/__tests__/VariableRegistry.test.js
+++ b/src/components/Cards/__tests__/VariableRegistry.test.js
@@ -10,7 +10,7 @@ const mockProps = {
     edge: {},
   },
   getUsageForType: () => {},
-  deleteTypeAndRelatedObjects: () => {},
+  deleteType: () => {},
   protocolPath: '',
 };
 

--- a/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
+++ b/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
@@ -5,7 +5,8 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VariableRegistry
-    deleteType={[Function]}
+    deleteTypeAndRelatedObjects={[Function]}
+    getUsageForType={[Function]}
     onComplete={[Function]}
     protocolPath=""
     show={true}

--- a/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
+++ b/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
@@ -5,7 +5,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VariableRegistry
-    deleteTypeAndRelatedObjects={[Function]}
+    deleteType={[Function]}
     getUsageForType={[Function]}
     onComplete={[Function]}
     protocolPath=""

--- a/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
+++ b/src/components/Cards/__tests__/__snapshots__/VariableRegistry.test.js.snap
@@ -6,6 +6,8 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VariableRegistry
     deleteType={[Function]}
+    getDeleteImpact={[Function]}
+    getObjectLabel={[Function]}
     getUsageForType={[Function]}
     onComplete={[Function]}
     protocolPath=""

--- a/src/ducks/modules/__tests__/session.test.js
+++ b/src/ducks/modules/__tests__/session.test.js
@@ -5,7 +5,7 @@ import { createEpicMiddleware } from 'redux-observable';
 import reducer, { actionCreators } from '../session';
 import { actionCreators as protocolActions } from '../protocol';
 import { actionCreators as stageActions } from '../protocol/stages';
-import { actionCreators as registryActions } from '../protocol/variableRegistry';
+import { actionCreators as registryActions, testing as registryTesting } from '../protocol/variableRegistry';
 import { actionCreators as formActions } from '../protocol/forms';
 import { rootEpic } from '../../modules/root';
 
@@ -68,7 +68,7 @@ describe('session reducer', () => {
     });
 
     it('tracks delete type as change', () => {
-      itTracksActionAsChange(registryActions.deleteType());
+      itTracksActionAsChange(registryTesting.deleteTypeAction());
     });
 
     it('tracks create form as change', () => {

--- a/src/ducks/modules/protocol/__tests__/stages.test.js
+++ b/src/ducks/modules/protocol/__tests__/stages.test.js
@@ -4,7 +4,16 @@ import reducer, { actionCreators } from '../stages';
 
 const mockStages = [
   { id: 3, type: 'Information', label: 'Foo' },
-  { id: 9, type: 'NameGenerator', label: 'Bar' },
+  {
+    id: 9,
+    type: 'NameGenerator',
+    label: 'Bar',
+    prompts: [
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+    ],
+  },
   { id: 5, type: 'OrdinalBin', label: 'Baz' },
 ];
 
@@ -66,6 +75,31 @@ describe('protocol.stages', () => {
         updatedStages,
       ).toEqual([
         { id: 3, type: 'Information', label: 'Foo' },
+        { id: 5, type: 'OrdinalBin', label: 'Baz' },
+      ]);
+    });
+  });
+
+  describe('DELETE_PROMPT', () => {
+    it('Deletes the stage with stageId', () => {
+      const updatedStages = reducer(
+        mockStages,
+        actionCreators.deletePrompt(9, 2),
+      );
+
+      expect(
+        updatedStages,
+      ).toEqual([
+        { id: 3, type: 'Information', label: 'Foo' },
+        {
+          id: 9,
+          type: 'NameGenerator',
+          label: 'Bar',
+          prompts: [
+            { id: 1 },
+            { id: 3 },
+          ],
+        },
         { id: 5, type: 'OrdinalBin', label: 'Baz' },
       ]);
     });

--- a/src/ducks/modules/protocol/variableRegistry.js
+++ b/src/ducks/modules/protocol/variableRegistry.js
@@ -59,7 +59,7 @@ function deleteTypeAndRelatedObjects(category, type) {
     const getUsageForType = makeGetUsageForType(getState());
     const usageForType = getUsageForType(category, type);
 
-    // dispatch(deleteType(category, type));
+    dispatch(deleteType(category, type));
 
     usageForType.forEach(({ owner }) => {
       switch (owner.type) {

--- a/src/ducks/modules/session.js
+++ b/src/ducks/modules/session.js
@@ -13,6 +13,7 @@ const savableChanges = [
   protocolStageActionTypes.MOVE_STAGE,
   protocolStageActionTypes.UPDATE_STAGE,
   protocolStageActionTypes.DELETE_STAGE,
+  protocolStageActionTypes.DELETE_PROMPT,
   protocolRegistryActionTypes.UPDATE_TYPE,
   protocolRegistryActionTypes.CREATE_TYPE,
   protocolRegistryActionTypes.DELETE_TYPE,

--- a/src/selectors/__tests__/variableRegistry.test.js
+++ b/src/selectors/__tests__/variableRegistry.test.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+
+import {
+  getTypeUsageIndex,
+  makeGetUsageForType,
+} from '../variableRegistry';
+
+const mockStateWithProtocol = {
+  protocol: {
+    present: {
+      stages: [
+        {
+          id: 'bazz',
+          subject: { entity: 'node', type: 'foo' },
+        },
+        {
+          id: 'pip',
+          subject: { entity: 'node', type: 'pop' },
+        },
+        {
+          id: 'buzz',
+          prompts: [
+            {
+              id: 'fizz',
+              subject: { entity: 'node', type: 'foo' },
+            },
+          ],
+        },
+      ],
+      forms: {
+        bar: {
+          entity: 'node',
+          type: 'foo',
+        },
+      },
+    },
+  },
+};
+
+describe('variableRegistry selectors', () => {
+  it('getTypeUsageIndex()', () => {
+    const result = getTypeUsageIndex(mockStateWithProtocol);
+
+    expect(result)
+      .toEqual(
+        [
+          {
+            owner: { id: 'bar', type: 'form' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+          {
+            owner: { id: 'bazz', type: 'stage' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+          {
+            owner: { id: 'pip', type: 'stage' },
+            subject: { entity: 'node', type: 'pop' },
+          },
+          {
+            owner: { promptId: 'fizz', stageId: 'buzz', type: 'prompt' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+        ],
+      );
+  });
+
+  it('makeGetUsageForType()', () => {
+    const getUsageForType = makeGetUsageForType(mockStateWithProtocol);
+    const result = getUsageForType('node', 'pop');
+
+    expect(result)
+      .toEqual([
+        {
+          owner: { id: 'pip', type: 'stage' },
+          subject: { entity: 'node', type: 'pop' },
+        },
+      ]);
+  });
+});

--- a/src/selectors/__tests__/variableRegistry.test.js
+++ b/src/selectors/__tests__/variableRegistry.test.js
@@ -3,6 +3,7 @@
 import {
   getTypeUsageIndex,
   makeGetUsageForType,
+  getSociogramTypeUsageIndex,
 } from '../variableRegistry';
 
 const mockStateWithProtocol = {
@@ -26,6 +27,19 @@ const mockStateWithProtocol = {
             },
           ],
         },
+        {
+          id: 'alpha',
+          type: 'Sociogram',
+          prompts: [
+            {
+              id: 'bravo',
+              edges: {
+                creates: 'charlie',
+                display: ['delta', 'echo'],
+              },
+            },
+          ],
+        },
       ],
       forms: {
         bar: {
@@ -38,6 +52,26 @@ const mockStateWithProtocol = {
 };
 
 describe('variableRegistry selectors', () => {
+  it('getSociogramTypeUsageIndex()', () => {
+    const result = getSociogramTypeUsageIndex(mockStateWithProtocol);
+
+    expect(result)
+      .toEqual(
+        [
+          {
+            owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
+            subject: { entity: 'edge', type: 'charlie' },
+          }, {
+            owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
+            subject: { entity: 'edge', type: 'delta' },
+          }, {
+            owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
+            subject: { entity: 'edge', type: 'echo' },
+          },
+        ],
+      );
+  });
+
   it('getTypeUsageIndex()', () => {
     const result = getTypeUsageIndex(mockStateWithProtocol);
 
@@ -60,19 +94,49 @@ describe('variableRegistry selectors', () => {
             owner: { promptId: 'fizz', stageId: 'buzz', type: 'prompt' },
             subject: { entity: 'node', type: 'foo' },
           },
+          {
+            owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
+            subject: { entity: 'edge', type: 'charlie' },
+          }, {
+            owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
+            subject: { entity: 'edge', type: 'delta' },
+          }, {
+            owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
+            subject: { entity: 'edge', type: 'echo' },
+          },
         ],
       );
   });
 
   it('makeGetUsageForType()', () => {
+    let result;
     const getUsageForType = makeGetUsageForType(mockStateWithProtocol);
-    const result = getUsageForType('node', 'pop');
+
+    result = getUsageForType('node', 'pop');
 
     expect(result)
       .toEqual([
         {
           owner: { id: 'pip', type: 'stage' },
           subject: { entity: 'node', type: 'pop' },
+        },
+      ]);
+
+    result = getUsageForType('node', 'foo');
+
+    expect(result)
+      .toEqual([
+        {
+          owner: { id: 'bar', type: 'form' },
+          subject: { entity: 'node', type: 'foo' },
+        },
+        {
+          owner: { id: 'bazz', type: 'stage' },
+          subject: { entity: 'node', type: 'foo' },
+        },
+        {
+          owner: { promptId: 'fizz', stageId: 'buzz', type: 'prompt' },
+          subject: { entity: 'node', type: 'foo' },
         },
       ]);
   });

--- a/src/selectors/__tests__/variableRegistry.test.js
+++ b/src/selectors/__tests__/variableRegistry.test.js
@@ -3,6 +3,7 @@
 import {
   getTypeUsageIndex,
   makeGetUsageForType,
+  makeGetDeleteImpact,
   getSociogramTypeUsageIndex,
 } from '../variableRegistry';
 
@@ -24,6 +25,19 @@ const mockStateWithProtocol = {
             {
               id: 'fizz',
               subject: { entity: 'node', type: 'foo' },
+            },
+          ],
+        },
+        {
+          id: 'foxtrot',
+          prompts: [
+            {
+              id: 'golf',
+              subject: { entity: 'node', type: 'foo' },
+            },
+            {
+              id: 'hotel',
+              subject: { entity: 'node', type: 'pop' },
             },
           ],
         },
@@ -95,6 +109,14 @@ describe('variableRegistry selectors', () => {
             subject: { entity: 'node', type: 'foo' },
           },
           {
+            owner: { promptId: 'golf', stageId: 'foxtrot', type: 'prompt' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+          {
+            owner: { promptId: 'hotel', stageId: 'foxtrot', type: 'prompt' },
+            subject: { entity: 'node', type: 'pop' },
+          },
+          {
             owner: { promptId: 'bravo', stageId: 'alpha', type: 'prompt' },
             subject: { entity: 'edge', type: 'charlie' },
           }, {
@@ -108,36 +130,61 @@ describe('variableRegistry selectors', () => {
       );
   });
 
-  it('makeGetUsageForType()', () => {
-    let result;
+  describe('makeGetUsageForType()', () => {
     const getUsageForType = makeGetUsageForType(mockStateWithProtocol);
 
-    result = getUsageForType('node', 'pop');
+    it('returns correct results for ["node", "pop"]', () => {
+      const result = getUsageForType('node', 'pop');
+
+      expect(result)
+        .toEqual([
+          {
+            owner: { id: 'pip', type: 'stage' },
+            subject: { entity: 'node', type: 'pop' },
+          },
+          {
+            owner: { promptId: 'hotel', stageId: 'foxtrot', type: 'prompt' },
+            subject: { entity: 'node', type: 'pop' },
+          },
+        ]);
+    });
+
+    it('returns correct results for ["node", "foo"]', () => {
+      const result = getUsageForType('node', 'foo');
+
+      expect(result)
+        .toEqual([
+          {
+            owner: { id: 'bar', type: 'form' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+          {
+            owner: { id: 'bazz', type: 'stage' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+          {
+            owner: { promptId: 'fizz', stageId: 'buzz', type: 'prompt' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+          {
+            owner: { promptId: 'golf', stageId: 'foxtrot', type: 'prompt' },
+            subject: { entity: 'node', type: 'foo' },
+          },
+        ]);
+    });
+  });
+
+  it('makeGetDeleteImpact("node", "foo")', () => {
+    const getDeleteImpact = makeGetDeleteImpact(mockStateWithProtocol);
+
+    const result = getDeleteImpact('node', 'foo');
 
     expect(result)
       .toEqual([
-        {
-          owner: { id: 'pip', type: 'stage' },
-          subject: { entity: 'node', type: 'pop' },
-        },
-      ]);
-
-    result = getUsageForType('node', 'foo');
-
-    expect(result)
-      .toEqual([
-        {
-          owner: { id: 'bar', type: 'form' },
-          subject: { entity: 'node', type: 'foo' },
-        },
-        {
-          owner: { id: 'bazz', type: 'stage' },
-          subject: { entity: 'node', type: 'foo' },
-        },
-        {
-          owner: { promptId: 'fizz', stageId: 'buzz', type: 'prompt' },
-          subject: { entity: 'node', type: 'foo' },
-        },
+        { id: 'bar', type: 'form' },
+        { id: 'bazz', type: 'stage' },
+        { id: 'buzz', type: 'stage' },
+        { promptId: 'golf', stageId: 'foxtrot', type: 'prompt' },
       ]);
   });
 });

--- a/src/selectors/variableRegistry.js
+++ b/src/selectors/variableRegistry.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
-import { get, map, reduce, compact, flatMap, memoize } from 'lodash';
+import { get, map, compact, flatMap, memoize } from 'lodash';
 import { createSelector } from 'reselect';
 import { getProtocol } from './protocol';
 

--- a/src/selectors/variableRegistry.js
+++ b/src/selectors/variableRegistry.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
-import { get } from 'lodash';
+import { get, map, reduce, flatMap } from 'lodash';
+import { createSelector } from 'reselect';
 import { getProtocol } from './protocol';
 
 const getNodeTypes = state =>
@@ -9,4 +10,67 @@ const getNodeTypes = state =>
 const getVariablesForNodeType = (state, nodeType) =>
   get(getNodeTypes(state), [nodeType, 'variables'], {});
 
-export { getNodeTypes, getVariablesForNodeType };
+const getFormTypeUsageIndex = createSelector(
+  getProtocol,
+  protocol =>
+    map(protocol.forms, ({ entity, type }, id) => ({ id, entity, type, parent: 'form' })),
+);
+
+const getStagesWithSubject = createSelector(
+  getProtocol,
+  protocol =>
+    protocol.stages.filter(stage => !!stage.subject),
+);
+
+const getStageTypeUsageIndex = createSelector(
+  getStagesWithSubject,
+  stagesWithSubject =>
+    map(stagesWithSubject, ({ subject: { entity, type }, id }) => ({ id, entity, type, parent: 'stage' })),
+);
+
+const getTypeUsageIndex = createSelector(
+  getFormTypeUsageIndex,
+  getStageTypeUsageIndex,
+  (formTypeIndex, stageTypeIndex) =>
+    [...formTypeIndex, ...stageTypeIndex],
+);
+
+const getUsageForType = (typeUsageIndex, searchEntity, searchType) =>
+  typeUsageIndex.filter(
+    ({ type, entity }) =>
+      type === searchType && entity === searchEntity,
+  );
+
+const getTypes = createSelector(
+  getProtocol,
+  protocol =>
+    flatMap(
+      protocol.variableRegistry,
+      (entityTypes, entity) =>
+        map(entityTypes, (_, type) => ({ entity, type })),
+    ),
+);
+
+const getTypeUsage = createSelector(
+  getTypes,
+  getTypeUsageIndex,
+  (types, typeUsageIndex) =>
+    types.reduce(
+      (memo, { entity, type }) => ({
+        ...memo,
+        [entity]: {
+          ...memo[entity],
+          [type]: getUsageForType(typeUsageIndex, entity, type),
+        },
+      }),
+      {},
+    ),
+);
+
+
+export {
+  getNodeTypes,
+  getVariablesForNodeType,
+  getTypeUsage,
+  getTypes,
+};

--- a/src/selectors/variableRegistry.js
+++ b/src/selectors/variableRegistry.js
@@ -187,7 +187,7 @@ const makeGetDeleteImpact = createSelector(
 
               return owner;
             }),
-          ({ id, type }) => `${id}:${type}`,
+          ({ type, ...owner }) => (owner.id ? `${owner.id}:${type}` : `${owner.stageId}:${owner.promptId}:${type}`),
         );
 
         return deletedObjects;
@@ -220,10 +220,14 @@ const makeGetObjectLabel = createSelector(
             return protocol.forms[protocolObject.id].title;
           case 'stage':
             return protocol.stages.find(({ id }) => id === protocolObject.id).label;
-          case 'prompt':
-            return protocol.stages
+          case 'prompt': {
+            const stageLabel = protocol.stages.find(({ id }) =>
+              id === protocolObject.stageId).label;
+            const promptLabel = protocol.stages
               .find(({ id }) => id === protocolObject.stageId).prompts
               .find(({ id }) => id === protocolObject.promptId).text;
+            return `${stageLabel} -> ${promptLabel}`;
+          }
           default:
             return '';
         }

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -26,3 +26,4 @@
 @import './components/protocol-stack';
 @import './components/error';
 @import './components/issues';
+@import './components/list';

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -21,6 +21,7 @@
   // Errors
   --architect-error-background: var(--color-rich-black);
   --architect-error-code-background: var(--color-shadow);
+  --architect-warning: var(--color-tomato);
 
   --architect-media-background: var(--color-rich-black);
 

--- a/src/styles/components/_list.scss
+++ b/src/styles/components/_list.scss
@@ -1,0 +1,30 @@
+.list {
+  &:first-child {
+    border-top: unit(.25) solid var(--architect-divider);
+  }
+
+  &__item {
+    display: flex;
+    width: 100%;
+    border-bottom: unit(.25) solid var(--architect-divider);
+  }
+
+  &__attribute {
+    display: flex;
+    flex-grow: 1;
+    flex-basis: auto;
+    justify-content: flex-start;
+    align-items: center;
+    padding: unit(2) unit(1);
+
+    a {
+      text-decoration: none;
+      color: var(--text);
+      cursor: pointer;
+    }
+
+    h3 {
+      margin: 0;
+    }
+  }
+}

--- a/src/styles/components/_variable-registry.scss
+++ b/src/styles/components/_variable-registry.scss
@@ -13,5 +13,15 @@
         flex-grow: 0;
       }
     }
+
+    &__tag {
+      @include typography('copy-small');
+      display: inline-block;
+      border-radius: unit(.5);
+      padding: unit(.3) unit(.5);
+      margin-left: unit(1);
+      color: var(--text-light);
+      background-color: var(--architect-warning);
+    }
   }
 }

--- a/src/styles/shared/_editor.scss
+++ b/src/styles/shared/_editor.scss
@@ -42,35 +42,4 @@
       padding-top: calc(30vh);
     }
   }
-
-  .list {
-    &:first-child {
-      border-top: unit(.25) solid var(--architect-divider);
-    }
-
-    &__item {
-      display: flex;
-      width: 100%;
-      border-bottom: unit(.25) solid var(--architect-divider);
-    }
-
-    &__attribute {
-      display: flex;
-      flex-grow: 1;
-      flex-basis: auto;
-      justify-content: flex-start;
-      align-items: center;
-      padding: unit(2) unit(1);
-
-      a {
-        text-decoration: none;
-        color: var(--text);
-        cursor: pointer;
-      }
-
-      h3 {
-        margin: 0;
-      }
-    }
-  }
 }

--- a/src/utils/protocol.js
+++ b/src/utils/protocol.js
@@ -1,0 +1,16 @@
+/* eslint-disable import/prefer-default-export */
+
+export const getObjectLabel = (protocol, protocolObject) => {
+  switch (protocolObject.type) {
+    case 'form':
+      return protocol.forms[protocolObject.id].title;
+    case 'stage':
+      return protocol.stages.find(({ id }) => id === protocolObject.id).label;
+    case 'prompt':
+      return protocol.stages
+        .find(({ id }) => id === protocolObject.stageId).prompts
+        .find(({ id }) => id === protocolObject.promptId).text;
+    default:
+      return '';
+  }
+};

--- a/src/utils/webShims/mockProtocol.json
+++ b/src/utils/webShims/mockProtocol.json
@@ -877,8 +877,8 @@
             "allowPositioning": true
           },
           "edges": {
-            "display": ["friends", "professional"],
-            "create": "friends"
+            "display": ["friend", "professional"],
+            "create": "friend"
           },
           "highlight": {
             "variable": "has_given_advice",

--- a/src/utils/webShims/mockProtocol.json
+++ b/src/utils/webShims/mockProtocol.json
@@ -773,7 +773,7 @@
     {
       "id": "namegenroster2",
       "type": "NameGeneratorList",
-      "label": "NG Classmates",
+      "label": "NG Classmates 2",
       "showExistingNodes": false,
       "prompts": [
         {


### PR DESCRIPTION
When deleting a type, checks for usage and deletes any affected objects.

Implemented as a switch on the deleteType action `deleteType(entity, type, deleteRelatedObjects = false)`

- [x] When deleting a type notify user of the impact on other objects.
  - Currently implemented as a confirm dialog - thinking this might be better as an in-app modal so that we can do more with UI.
- [x] Delete any associated stages/forms.
- [x] Add information to node/edges registry indicating where assets are used

Resolves #232 