### PR TITLE
Fix logger setup

### DIFF
--- a/public/components/log.js
+++ b/public/components/log.js
@@ -1,15 +1,9 @@
-const electron = require('electron');
-const path = require('path');
-const fs = require('fs');
 const log = require('electron-log');
-
-const userDataPath = (electron.app || electron.remote.app).getPath('userData');
 
 log.transports.console.level = false;
 log.transports.file.level = 'log';
 log.transports.file.format = '{h}:{i}:{s}:{ms} {text}';
 log.transports.file.maxSize = 5 * 1024 * 1024;
-log.transports.file.streamConfig = { flags: 'w+' };
-log.transports.file.stream = fs.createWriteStream(path.join(userDataPath, 'debug.log'));
+log.transports.file.streamConfig = { flags: 'w' };
 
 module.exports = log;

--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -1,5 +1,5 @@
 const { app } = require('electron');
-const log = require('electron-log');
+const log = require('./components/log');
 
 const appManager = require('./components/appManager');
 


### PR DESCRIPTION
Fixes #243.

This uses the [default log location from electron-log](https://github.com/megahertz/electron-log/blob/fc1c768/lib/transports/file/find-log-path.js#L15-L54), which is the most straightforward fix.

If the log needs to be written into the userData dir, then we'll need to either:
- rely on electron's `getPath` but ensure that log setup (and, consequently, logging) calls are only made after electron's ready event, or
- implement our own directory resolution like electron-log's above, and create that location if it doesn't exist (knowing that electron will also be looking to create it)

Other minor changes:

- Mode changed from 'w+' to 'w'; logger shouldn't need read access. (Note: the default behavior would be to append.)
- Update require in electron-starter for clarity; custom setup needs to happen before the first logging call.