### PR TITLE
Update sortOrder prop to match expected NC schema

### DIFF
--- a/src/components/StageEditor/sections/SociogramPrompts/SociogramPrompt.js
+++ b/src/components/StageEditor/sections/SociogramPrompts/SociogramPrompt.js
@@ -157,10 +157,10 @@ class SociogramPrompt extends Component {
                 />
               </div>
             </Guidance>
-            <Guidance contentId="guidance.editor.sociogram_prompt.sortOrderBy">
+            <Guidance contentId="guidance.editor.sociogram_prompt.sortOrder">
               <div>
                 <Field
-                  name="sortOrderBy"
+                  name="sortOrder"
                   component={ArchitectFields.OrderBy}
                   className="stage-editor-section-prompt__setting"
                   variables={variablesForNodeType}

--- a/src/components/StageEditor/sections/SociogramPrompts/SociogramPrompts.js
+++ b/src/components/StageEditor/sections/SociogramPrompts/SociogramPrompts.js
@@ -66,7 +66,7 @@ const mapDispatchToProps = (dispatch, { form: { name } }) => ({
         text: '',
         subject: {},
         layout: { allowPositioning: true },
-        sortOrderBy: [],
+        sortOrder: [],
         background: { concentricCircles: 4, skewedTowardCenter: false },
       },
     ),

--- a/src/components/StageEditor/sections/SociogramPrompts/__tests__/SociogramPrompts.test.js
+++ b/src/components/StageEditor/sections/SociogramPrompts/__tests__/SociogramPrompts.test.js
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+
+import SociogramPrompts from '../SociogramPrompts';
+
+jest.mock('../../../../Guidance');
+
+describe('<SociogramPrompts />', () => {
+  describe('when connected', () => {
+    let subject;
+    beforeEach(() => {
+      const store = createStore(() => ({}));
+      const props = { form: { name: 'myForm' } };
+      const provider = mount(<Provider store={store}><SociogramPrompts {...props} /></Provider>);
+      subject = provider.find('SociogramPrompts');
+    });
+
+    it('defines sortOrder for new prompts', async () => {
+      const addFunc = subject.prop('addNewPrompt');
+      expect(addFunc).toBeInstanceOf(Function);
+      expect(addFunc().payload).toMatchObject({ sortOrder: [] });
+    });
+  });
+});

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -104,7 +104,7 @@ export default {
       <p>guidance.editor.sociogram_prompt.edges</p>
     </Fragment>
   ),
-  'guidance.editor.sociogram_prompt.sortOrderBy': (
+  'guidance.editor.sociogram_prompt.sortOrder': (
     <Fragment>
       <h3>Sort order</h3>
       <p>


### PR DESCRIPTION
Fixes #254.

Change to schema: "sortOrderBy" fields should be renamed to "sortOrder". Can be validated with the [feature/schema branch of NC](https://github.com/codaco/Network-Canvas/issues/697).
