### PR TITLE
Fix form creation

### DIFF
--- a/src/components/FormEditor/NodeType.js
+++ b/src/components/FormEditor/NodeType.js
@@ -7,12 +7,13 @@ const NodeType = ({
   color,
   input: { value, checked, onChange },
 }) => (
-  <Node
-    onClick={() => onChange(value)}
-    label={label}
-    selected={checked}
-    color={color}
-  />
+  <div className="node-type" onClick={() => onChange(value)}>
+    <Node
+      label={label}
+      selected={checked}
+      color={color}
+    />
+  </div>
 );
 
 NodeType.propTypes = {

--- a/src/styles/components/form/fields/_node-select.scss
+++ b/src/styles/components/form/fields/_node-select.scss
@@ -1,11 +1,14 @@
 .form-fields-node-select {
-  display: block;
   background: none;
+  display: block;
   padding: 0;
 
-  .node {
+  .node-type {
     display: inline-block;
-    font-size: 7rem;
     margin-right: unit(2);
+
+    .node {
+      font-size: 7rem;
+    }
   }
 }


### PR DESCRIPTION
Fixes #263.

Captures the click above the UI component, since `<Node />` no longer receives arbitrary props.

Regression test added to [integration-tests](https://github.com/codaco/integration-tests/pull/4).