### PR TITLE
Prevent app from accepting dropped files/snippets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,16 @@ import Routes from './routes';
 import ClipPaths from './components/ClipPaths';
 import { actionCreators as protocolsActions } from './ducks/modules/protocols';
 
+// This prevents user from being able to drop a file anywhere on the app
+document.addEventListener('drop', (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+});
+document.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+});
+
 initReactFastclick();
 
 const startApp = () => {


### PR DESCRIPTION
Fixes #280.

This is duplicated in NC with https://github.com/codaco/Network-Canvas/pull/745, and there's equivalent functionality in Server; we can clean up/refactor in the future.