### PR TITLE
Fix option color on Windows

### DIFF
--- a/src/styles/components/rule/_rule-drop-down.scss
+++ b/src/styles/components/rule/_rule-drop-down.scss
@@ -23,5 +23,9 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+
+    option {
+      color: var(--text-dark); // Needed for dropdown on Windows
+    }
   }
 }


### PR DESCRIPTION
This seems to fix the text display issue on Windows.

<img width="847" alt="windows" src="https://user-images.githubusercontent.com/39674/48228536-721c4680-e373-11e8-81f3-020c10592a0d.png">

Fixes #272.