### PR TITLE
Remove version from protocol template

### DIFF
--- a/src/other/protocols/template.json
+++ b/src/other/protocols/template.json
@@ -1,6 +1,5 @@
 {
   "name": "Protocol",
-  "version": "1.0.0",
   "variableRegistry": {
     "node": {
       "d39a47507bbe27c2a7948861847f3607eda8e1be": {


### PR DESCRIPTION
Fixes the second part of #296. Version is superseded by lastModified.