### PR TITLE
Make entire stage button clickable

### DIFF
--- a/src/components/Timeline/Stage.js
+++ b/src/components/Timeline/Stage.js
@@ -18,12 +18,11 @@ const EditStageButton = Zoom(
     type,
     label,
   }) => (
-    <div className="timeline-stage__edit-stage">
+    <div className="timeline-stage__edit-stage" onClick={onEditStage}>
       <div className="timeline-stage__edit-stage-title">{label || '\u00A0'}</div>
       <div
         className="timeline-stage__screen"
         role="button"
-        onClick={onEditStage}
         tabIndex="0"
       >
         <div className="timeline-stage__screen-preview">


### PR DESCRIPTION
Make entire stage button clickable. Otherwise, the Zoom effect plays but no navigation happens.

To test, click the stage title; you should be taken to the stage editor.

<img width="496" alt="stage-title" src="https://user-images.githubusercontent.com/39674/48722196-72c5a000-ebf1-11e8-96a5-5f14593229c2.png">
