### PR TITLE
disable blurInputOnSelect for touch devices

### DIFF
--- a/src/components/Form/Fields/Select.js
+++ b/src/components/Form/Fields/Select.js
@@ -89,6 +89,7 @@ class Select extends PureComponent {
               input.onBlur(input.value);
             }
           }}
+          blurInputOnSelect={false}
           {...rest}
         >
           {children}


### PR DESCRIPTION
This disables blur on select for touch devices, since blur was overwriting change values. Fixes #334.