### PR TITLE
Fix window reference

### DIFF
--- a/public/components/previewWindowManager.js
+++ b/public/components/previewWindowManager.js
@@ -185,7 +185,7 @@ function createWindow() {
     global.previewWindow.loadURL(getAppUrl());
 
     if (process.env.NODE_ENV === 'development') {
-      global.appWindow.openDevTools();
+      global.previewWindow.openDevTools();
     }
   });
 }


### PR DESCRIPTION
On master, when I run `electron:dev` (macOS) before the dev server has finished starting up, electron crashes. I tracked it down to this line, where it looked like `previewWindow` was intended.

It doesn't look like this affects anything other than the dev workflow, but would be good to confirm there aren't any other unexpected issues between the two browserWindows (since I don't really understand what the actual cause is).

Partial crash dump for reference:

```
Crashed Thread:        0  CrBrowserMain  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Illegal instruction: 4
Termination Reason:    Namespace SIGNAL, Code 0x4
Terminating Process:   exc handler [0]

Application Specific Information:
Crashing on exception: *** -[__NSArrayM objectAtIndex:]: index 1 beyond bounds [0 .. 0]

Application Specific Backtrace 1:
0   CoreFoundation                      0x00007fff4158723b __exceptionPreprocess + 171
1   libobjc.A.dylib                     0x00007fff68819c76 objc_exception_throw + 48
2   CoreFoundation                      0x00007fff415c84c4 _CFThrowFormattedException + 202
3   CoreFoundation                      0x00007fff414a6300 __CFStringDecodeByteStream3 + 0
4   Electron Framework                  0x0000000108c38569 _ZN9brightray8IOThread7CleanUpEv + 2281
5   Electron Framework                  0x0000000108c37e71 _ZN9brightray8IOThread7CleanUpEv + 497
6   AppKit                              0x00007fff3eabe6f6 -[NSView setFrameSize:] + 1672
```