### PR TITLE
[WIP] Make filter group more reuseable

### DIFF
--- a/src/components/Cards/EditSkipLogic.js
+++ b/src/components/Cards/EditSkipLogic.js
@@ -6,7 +6,7 @@ import { get, find } from 'lodash';
 import { Button } from '../../ui/components';
 import { actionCreators as stageActions } from '../../ducks/modules/protocol/stages';
 import Card from './ProtocolCard';
-import { getProtocol } from '../../selectors/protocol';
+import { getProtocol, getVariableRegistry } from '../../selectors/protocol';
 import { Draft } from '../../behaviours';
 import SkipLogicEditor from '../SkipLogicEditor';
 
@@ -29,6 +29,7 @@ class EditSkipLogic extends PureComponent {
     draft: PropTypes.any.isRequired,
     updateStage: PropTypes.func.isRequired,
     updateDraft: PropTypes.func.isRequired,
+    variableRegistry: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -67,6 +68,7 @@ class EditSkipLogic extends PureComponent {
     const {
       show,
       draft,
+      variableRegistry,
     } = this.props;
 
     return (
@@ -76,7 +78,11 @@ class EditSkipLogic extends PureComponent {
         show={show}
         onCancel={this.handleCancel}
       >
-        <SkipLogicEditor onChange={this.handleChange} rules={draft} />
+        <SkipLogicEditor
+          onChange={this.handleChange}
+          rules={draft}
+          variableRegistry={variableRegistry}
+        />
       </Card>
     );
   }
@@ -87,10 +93,12 @@ const mapStateToProps = (state, props) => {
   const protocol = getProtocol(state);
   const stage = find(protocol.stages, ['id', stageId]);
   const logic = get(stage, 'skipLogic', defaultLogic);
+  const variableRegistry = getVariableRegistry(state);
 
   return {
     stageId,
     draft: logic,
+    variableRegistry,
   };
 };
 

--- a/src/components/Cards/__tests__/EditSkipLogic.test.js
+++ b/src/components/Cards/__tests__/EditSkipLogic.test.js
@@ -10,6 +10,7 @@ const mockProps = {
   updateDraft: () => {},
   rules: {},
   onChange: () => {},
+  variableRegistry: {},
 };
 
 describe('<EditForm />', () => {

--- a/src/components/Cards/__tests__/__snapshots__/EditSkipLogic.test.js.snap
+++ b/src/components/Cards/__tests__/__snapshots__/EditSkipLogic.test.js.snap
@@ -13,6 +13,7 @@ ShallowWrapper {
     stageId={null}
     updateDraft={[Function]}
     updateStage={[Function]}
+    variableRegistry={Object {}}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -31,6 +32,7 @@ ShallowWrapper {
       "children": <SkipLogicEditor
         onChange={[Function]}
         rules={Object {}}
+        variableRegistry={Object {}}
       />,
       "onCancel": [Function],
       "show": false,
@@ -44,6 +46,7 @@ ShallowWrapper {
       "props": Object {
         "onChange": [Function],
         "rules": Object {},
+        "variableRegistry": Object {},
       },
       "ref": null,
       "rendered": null,
@@ -61,6 +64,7 @@ ShallowWrapper {
         "children": <SkipLogicEditor
           onChange={[Function]}
           rules={Object {}}
+          variableRegistry={Object {}}
         />,
         "onCancel": [Function],
         "show": false,
@@ -74,6 +78,7 @@ ShallowWrapper {
         "props": Object {
           "onChange": [Function],
           "rules": Object {},
+          "variableRegistry": Object {},
         },
         "ref": null,
         "rendered": null,

--- a/src/components/Filter/FilterGroup.js
+++ b/src/components/Filter/FilterGroup.js
@@ -41,6 +41,7 @@ class FilterGroup extends PureComponent {
   static propTypes = {
     filter: PropTypes.object,
     onChange: PropTypes.func,
+    variableRegistry: PropTypes.object.isRequired,
     variableTypes: PropTypes.object.isRequired,
   };
 
@@ -109,7 +110,7 @@ class FilterGroup extends PureComponent {
   };
 
   render() {
-    const { join, rules } = this.props.filter;
+    const { filter: { join, rules }, variableRegistry } = this.props;
 
     return (
       <div className={filterGroupClasses(join)}>
@@ -129,6 +130,7 @@ class FilterGroup extends PureComponent {
             onUpdateRule={this.onUpdateRule}
             onDeleteRule={this.onDeleteRule}
             onSortEnd={this.onMoveRule}
+            variableRegistry={variableRegistry}
           />
 
           <div className="filter-group__add">
@@ -140,8 +142,8 @@ class FilterGroup extends PureComponent {
   }
 }
 
-const mapStateToProps = state => ({
-  variableTypes: getVariableTypes(state),
+const mapStateToProps = (state, ownProps) => ({
+  variableTypes: getVariableTypes(state, ownProps),
 });
 
 export { FilterGroup };

--- a/src/components/Filter/Rule/AlterRule.js
+++ b/src/components/Filter/Rule/AlterRule.js
@@ -8,7 +8,6 @@ import { SortableElement } from 'react-sortable-hoc';
 import DragHandle from './DragHandle';
 import DropDown from './DropDown';
 import Input from './Input';
-import { getVariableRegistry } from '../../../selectors/protocol';
 import { getVariableOptions } from './selectors';
 import { getOperatorsForType } from './operators';
 
@@ -123,8 +122,7 @@ class AlterRule extends PureComponent {
   }
 }
 
-function mapStateToProps(state, { options }) {
-  const variableRegistry = getVariableRegistry(state);
+function mapStateToProps(state, { options, variableRegistry }) {
   const nodeTypes = map(variableRegistry.node, (node, nodeId) => [nodeId, node.name]);
   const valueInputType = options ?
     get(variableRegistry.node, [options.type, 'variables', options.attribute, 'type']) :

--- a/src/components/Filter/Rule/AlterRule.js
+++ b/src/components/Filter/Rule/AlterRule.js
@@ -117,7 +117,7 @@ class AlterRule extends PureComponent {
             </div>
           )}
         </div>
-        <div className="rule__delete" onClick={() => onDeleteRule(id)} />
+        <button className="rule__delete" onClick={() => onDeleteRule(id)} />
       </div>
     );
   }

--- a/src/components/Filter/Rule/EdgeRule.js
+++ b/src/components/Filter/Rule/EdgeRule.js
@@ -8,7 +8,6 @@ import { SortableElement } from 'react-sortable-hoc';
 import DragHandle from './DragHandle';
 import DropDown from './DropDown';
 import Input from './Input';
-import { getVariableRegistry } from '../../../selectors/protocol';
 import { getVariableOptions } from './selectors';
 import { getOperatorsForType } from './operators';
 
@@ -123,8 +122,7 @@ class EdgeRule extends PureComponent {
   }
 }
 
-function mapStateToProps(state, { options }) {
-  const variableRegistry = getVariableRegistry(state);
+function mapStateToProps(state, { options, variableRegistry }) {
   const edgeTypes = map(variableRegistry.edge, (edge, edgeId) => [edgeId, edge.name]);
   const valueInputType = options ?
     get(variableRegistry.node, [options.type, 'variables', options.attribute, 'type']) :

--- a/src/components/Filter/Rule/EdgeRule.js
+++ b/src/components/Filter/Rule/EdgeRule.js
@@ -117,7 +117,7 @@ class EdgeRule extends PureComponent {
             </div>
           )}
         </div>
-        <div className="rule__delete" onClick={() => onDeleteRule(id)} />
+        <button className="rule__delete" onClick={() => onDeleteRule(id)} />
       </div>
     );
   }

--- a/src/components/Filter/Rule/EgoRule.js
+++ b/src/components/Filter/Rule/EgoRule.js
@@ -9,7 +9,6 @@ import DragHandle from './DragHandle';
 import DropDown from './DropDown';
 import Input from './Input';
 import { getVariableOptions } from './selectors';
-import { getVariableRegistry } from '../../../selectors/protocol';
 import { getOperatorsForType } from './operators';
 
 class EgoRule extends PureComponent {
@@ -112,8 +111,7 @@ class EgoRule extends PureComponent {
 
 
 // TODO: person is an implicitly required node type
-function mapStateToProps(state, { options }) {
-  const variableRegistry = getVariableRegistry(state);
+function mapStateToProps(state, { options, variableRegistry }) {
   const personType = find(toPairs(variableRegistry.node), ([, node]) => node.name === 'person');
   const personId = personType && personType[0];
   const valueInputType = options ?

--- a/src/components/Filter/Rule/EgoRule.js
+++ b/src/components/Filter/Rule/EgoRule.js
@@ -104,7 +104,7 @@ class EgoRule extends PureComponent {
           </div>
         }
         { !hasPersonType && <div>No &quot;Person&quot; node type found!</div> }
-        <div className="rule__delete" onClick={() => onDeleteRule(id)} />
+        <button className="rule__delete" onClick={() => onDeleteRule(id)} />
       </div>
     );
   }

--- a/src/components/Filter/Rule/__tests___/__snapshots__/AlterRule.test.js.snap
+++ b/src/components/Filter/Rule/__tests___/__snapshots__/AlterRule.test.js.snap
@@ -67,7 +67,7 @@ ShallowWrapper {
             />
           </div>
         </div>,
-        <div
+        <button
           className="rule__delete"
           onClick={[Function]}
         />,
@@ -171,7 +171,7 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": null,
-        "type": "div",
+        "type": "button",
       },
     ],
     "type": "div",
@@ -204,7 +204,7 @@ ShallowWrapper {
               />
             </div>
           </div>,
-          <div
+          <button
             className="rule__delete"
             onClick={[Function]}
           />,
@@ -308,7 +308,7 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": null,
-          "type": "div",
+          "type": "button",
         },
       ],
       "type": "div",

--- a/src/components/Filter/Rule/selectors.js
+++ b/src/components/Filter/Rule/selectors.js
@@ -2,7 +2,6 @@
 
 import { mapValues, reduce, isEqual } from 'lodash';
 import { defaultMemoize, createSelectorCreator } from 'reselect';
-import { getVariableRegistry } from '../../../selectors/protocol';
 
 const createDeepEqualSelector = createSelectorCreator(
   defaultMemoize,
@@ -17,6 +16,9 @@ const validTypes = [
   'categorical',
   'ordinal',
 ];
+
+// Registry is supplied as a prop to keep Filter contained & reusable
+const getVariableRegistry = (state, props) => props.variableRegistry;
 
 export const getVariableOptions = type =>
   mapValues(

--- a/src/components/Filter/Rules.js
+++ b/src/components/Filter/Rules.js
@@ -5,7 +5,7 @@ import Rule from './Rule';
 import AppearTransition from '../Transitions/Appear';
 
 const Rules = SortableContainer(
-  ({ rules, onUpdateRule, onDeleteRule }) => (
+  ({ rules, onUpdateRule, onDeleteRule, variableRegistry }) => (
     <TransitionGroup className="rules">
       {rules.map((rule, index) => (
         <AppearTransition
@@ -18,6 +18,7 @@ const Rules = SortableContainer(
             onUpdateRule={onUpdateRule}
             onDeleteRule={onDeleteRule}
             className="rules__rule"
+            variableRegistry={variableRegistry}
           />
         </AppearTransition>
       ))}

--- a/src/components/SkipLogicEditor.js
+++ b/src/components/SkipLogicEditor.js
@@ -9,6 +9,7 @@ class SkipLogicEditor extends PureComponent {
   static propTypes = {
     rules: PropTypes.any.isRequired,
     onChange: PropTypes.func.isRequired,
+    variableRegistry: PropTypes.object.isRequired,
   };
 
   render() {
@@ -21,6 +22,7 @@ class SkipLogicEditor extends PureComponent {
         filter,
         ...predicate
       },
+      variableRegistry,
     } = this.props;
 
     return (
@@ -50,6 +52,7 @@ class SkipLogicEditor extends PureComponent {
           <Filter
             filter={filter}
             onChange={newFilter => onChange({ filter: newFilter })}
+            variableRegistry={variableRegistry}
           />
         </div>
       </Guided>

--- a/src/components/StageEditor/sections/NodePanels/NodePanel.js
+++ b/src/components/StageEditor/sections/NodePanels/NodePanel.js
@@ -19,7 +19,7 @@ const getDataSourceOptions = (dataSources) => {
   ]);
 };
 
-const NodePanel = ({ fieldId, dataSources, ...rest }) => (
+const NodePanel = ({ fieldId, dataSources, variableRegistry, ...rest }) => (
   <Item {...rest}>
     <div className="stage-editor-section-prompt__group">
       <div className="stage-editor-section-prompt__group-title">Panel title</div>
@@ -48,6 +48,7 @@ const NodePanel = ({ fieldId, dataSources, ...rest }) => (
       <Field
         name={`${fieldId}.filter`}
         component={Filter}
+        variableRegistry={variableRegistry}
       />
     </div>
   </Item>
@@ -56,6 +57,7 @@ const NodePanel = ({ fieldId, dataSources, ...rest }) => (
 NodePanel.propTypes = {
   fieldId: PropTypes.string.isRequired,
   dataSources: PropTypes.array.isRequired,
+  variableRegistry: PropTypes.object.isRequired,
 };
 
 export { NodePanel };

--- a/src/components/StageEditor/sections/NodePanels/NodePanels.js
+++ b/src/components/StageEditor/sections/NodePanels/NodePanels.js
@@ -6,11 +6,12 @@ import { FieldArray, arrayPush } from 'redux-form';
 import uuid from 'uuid';
 import cx from 'classnames';
 import { keys, has, get } from 'lodash';
+import { getVariableRegistry } from '../../../../selectors/protocol';
 import Guidance from '../../../Guidance';
 import OrderedList, { NewButton } from '../../../OrderedList';
 import NodePanel from './NodePanel';
 
-const NodePanels = ({ form, createNewPanel, dataSources, disabled, panels }) => {
+const NodePanels = ({ form, createNewPanel, dataSources, disabled, panels, variableRegistry }) => {
   const isFull = panels && panels.length === 2;
 
   return (
@@ -25,6 +26,7 @@ const NodePanels = ({ form, createNewPanel, dataSources, disabled, panels }) => 
             item={NodePanel}
             form={form}
             dataSources={dataSources}
+            props={{ variableRegistry }}
           />
 
           { !isFull &&
@@ -47,6 +49,7 @@ NodePanels.propTypes = {
     name: PropTypes.string,
     getValues: PropTypes.func,
   }).isRequired,
+  variableRegistry: PropTypes.object.isRequired,
 };
 
 NodePanels.defaultProps = {
@@ -63,6 +66,7 @@ const mapStateToProps = (state, props) => ({
   disabled: !has(props.form.getValues(state, 'subject'), 'type'),
   dataSources: getDataSources(state),
   panels: props.form.getValues(state, 'panels'),
+  variableRegistry: getVariableRegistry(state),
 });
 
 const mapDispatchToProps = (dispatch, { form }) => ({

--- a/src/components/Transitions/Drawer.js
+++ b/src/components/Transitions/Drawer.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import anime from 'animejs';
 import { getCSSVariableAsNumber } from '../../utils/CSSVariables';
-import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 
 const appear = () => ({
   opacity: {
@@ -33,7 +32,7 @@ const FolderTransition = ({ children, ...props }) => (
     timeout={getCSSVariableAsNumber('--animation-duration-slow-ms')}
     onEntering={
       (el) => {
-        const { height } = getAbsoluteBoundingRect(el);
+        const { height } = el.getBoundingClientRect();
 
         anime({
           targets: el,

--- a/src/components/__tests__/Filter.test.js
+++ b/src/components/__tests__/Filter.test.js
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { Filter } from '../Filter';
 
 const mockProps = {
+  variableRegistry: {},
   variableTypes: {},
 };
 

--- a/src/components/__tests__/__snapshots__/Filter.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Filter.test.js.snap
@@ -11,6 +11,7 @@ ShallowWrapper {
       }
     }
     onChange={[Function]}
+    variableRegistry={Object {}}
     variableTypes={Object {}}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -64,6 +65,7 @@ ShallowWrapper {
             transitionDuration={300}
             useDragHandle={true}
             useWindowAsScrollContainer={false}
+            variableRegistry={Object {}}
           />
           <div
             className="filter-group__add"
@@ -142,6 +144,7 @@ ShallowWrapper {
               transitionDuration={300}
               useDragHandle={true}
               useWindowAsScrollContainer={false}
+              variableRegistry={Object {}}
             />,
             <div
               className="filter-group__add"
@@ -177,6 +180,7 @@ ShallowWrapper {
               "transitionDuration": 300,
               "useDragHandle": true,
               "useWindowAsScrollContainer": false,
+              "variableRegistry": Object {},
             },
             "ref": null,
             "rendered": null,
@@ -256,6 +260,7 @@ ShallowWrapper {
               transitionDuration={300}
               useDragHandle={true}
               useWindowAsScrollContainer={false}
+              variableRegistry={Object {}}
             />
             <div
               className="filter-group__add"
@@ -334,6 +339,7 @@ ShallowWrapper {
                 transitionDuration={300}
                 useDragHandle={true}
                 useWindowAsScrollContainer={false}
+                variableRegistry={Object {}}
               />,
               <div
                 className="filter-group__add"
@@ -369,6 +375,7 @@ ShallowWrapper {
                 "transitionDuration": 300,
                 "useDragHandle": true,
                 "useWindowAsScrollContainer": false,
+                "variableRegistry": Object {},
               },
               "ref": null,
               "rendered": null,


### PR DESCRIPTION
https://github.com/codaco/Server/pull/197 is making use of this version of the components.

In short, this removes the external selector/redux dependency from the FilterGroup component tree. `variableRegistry` is passed in to FilterGroup as a component prop. This happens in two places:

- NodePanels -> NodePanel
- EditSkipLogic -> SkipLogicEditor

Other minor changes:
- make the close buttons actual `button`s so that they're keyboard-accessible
- remove a 'getAbsoluteBoundingRect' import which wasn't needed; this animation can be more easily shared in UI in the future.