### PR TITLE
Fix/timeline styling and variable sorting

### DIFF
--- a/src/components/Timeline/Stage.js
+++ b/src/components/Timeline/Stage.js
@@ -19,7 +19,6 @@ const EditStageButton = Zoom(
     label,
   }) => (
     <div className="timeline-stage__edit-stage" onClick={onEditStage}>
-      <div className="timeline-stage__edit-stage-title">{label || '\u00A0'}</div>
       <div
         className="timeline-stage__screen"
         role="button"
@@ -40,6 +39,7 @@ const EditStageButton = Zoom(
           }
         </div>
       </div>
+      <h2 className="timeline-stage__edit-stage-title">{label || '\u00A0'}</h2>
     </div>
   ),
 );

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -144,7 +144,7 @@ class Timeline extends Component {
         index={index}
         id={stage.id}
         type={stage.type}
-        label={stage.label}
+        label={`${index + 1}. ${stage.label}`}
         onMouseEnter={this.handleMouseEnterStage}
         onMouseLeave={this.handleMouseLeaveStage}
         onEditStage={() => this.handleEditStage(stage.id)}

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -137,28 +137,23 @@ class Timeline extends Component {
     return itemsWithInsertStage;
   }
 
-  renderStage = (stage, index) => {
-    const className = cx({ 'timeline-stage--flip': index % 2 === 0 });
-
-    return (
-      <None key={`stage_${stage.id}`}>
-        <Stage
-          key={`stage_${stage.id}`}
-          index={index}
-          id={stage.id}
-          type={stage.type}
-          label={stage.label}
-          className={className}
-          onMouseEnter={this.handleMouseEnterStage}
-          onMouseLeave={this.handleMouseLeaveStage}
-          onEditStage={() => this.handleEditStage(stage.id)}
-          onDeleteStage={() => this.handleDeleteStage(stage.id)}
-          onInsertStage={position => this.handleInsertStage(index + position)}
-          onEditSkipLogic={() => this.handleEditSkipLogic(stage.id)}
-        />
-      </None>
-    );
-  }
+  renderStage = (stage, index) => (
+    <None key={`stage_${stage.id}`}>
+      <Stage
+        key={`stage_${stage.id}`}
+        index={index}
+        id={stage.id}
+        type={stage.type}
+        label={stage.label}
+        onMouseEnter={this.handleMouseEnterStage}
+        onMouseLeave={this.handleMouseLeaveStage}
+        onEditStage={() => this.handleEditStage(stage.id)}
+        onDeleteStage={() => this.handleDeleteStage(stage.id)}
+        onInsertStage={position => this.handleInsertStage(index + position)}
+        onEditSkipLogic={() => this.handleEditSkipLogic(stage.id)}
+      />
+    </None>
+  );
 
   render() {
     const { show, sorting } = this.props;

--- a/src/components/TypeEditor/Variables.js
+++ b/src/components/TypeEditor/Variables.js
@@ -59,6 +59,10 @@ class Variables extends Component {
               form={form}
               filter={filter}
               sortableProperties={['name', 'type']}
+              initialSortOrder={{
+                direction: 'asc',
+                property: 'name',
+              }}
             />
           </div>
         </div>

--- a/src/components/TypeEditor/Variables.js
+++ b/src/components/TypeEditor/Variables.js
@@ -33,9 +33,7 @@ const search = (list, query) => {
 
 const sort = (list, sortOrder) => {
   if (!sortOrder) { return list; }
-  const properties = sortOrder.map(({ property }) => property);
-  const orders = sortOrder.map(({ direction }) => direction);
-  return orderBy(list, properties, orders);
+  return orderBy(list, sortOrder.property, sortOrder.direction);
 };
 
 const filter = (list, { query, sortOrder }) => {
@@ -60,7 +58,7 @@ class Variables extends Component {
               name={name}
               form={form}
               filter={filter}
-              sortableProperties={['name']}
+              sortableProperties={['name', 'type']}
             />
           </div>
         </div>

--- a/src/components/UnorderedList/Controls.js
+++ b/src/components/UnorderedList/Controls.js
@@ -9,7 +9,10 @@ class Controls extends Component {
 
     this.state = {
       query: '',
-      sortOrder: [],
+      sortOrder: {
+        direction: 'asc',
+        property: 'name',
+      },
     };
   }
 
@@ -33,7 +36,7 @@ class Controls extends Component {
       <div className="list-controls">
         <div className="list-controls__section list-controls__section--search">
           <div className="list-controls__section-name">
-            Search:
+            Filter:
           </div>
           <Text
             input={{

--- a/src/components/UnorderedList/Controls.js
+++ b/src/components/UnorderedList/Controls.js
@@ -9,10 +9,7 @@ class Controls extends Component {
 
     this.state = {
       query: '',
-      sortOrder: {
-        direction: 'asc',
-        property: 'name',
-      },
+      sortOrder: this.props.initialSortOrder,
     };
   }
 
@@ -65,11 +62,13 @@ class Controls extends Component {
 Controls.propTypes = {
   onChange: PropTypes.func,
   sortableProperties: PropTypes.array,
+  initialSortOrder: PropTypes.object,
 };
 
 Controls.defaultProps = {
   onChange: () => {},
   sortableProperties: [],
+  initialSortOrder: {},
 };
 
 export default Controls;

--- a/src/components/UnorderedList/SortControl.js
+++ b/src/components/UnorderedList/SortControl.js
@@ -7,51 +7,25 @@ const getDirectionLabel = direction =>
 
 class SortControl extends Component {
   getIsSorted(checkedProperty) {
-    return this.props.sortOrder
-      .map(({ property }) => property)
-      .includes(checkedProperty);
-  }
-
-  getSortOption(property) {
-    const { sortOrder } = this.props;
-
-    const optionIndex = sortOrder.findIndex(sortRule => sortRule.property === property);
-
-    if (optionIndex === -1) {
-      return [
-        { property, direction: 'asc' },
-        sortOrder.length,
-      ];
-    }
-
-    return [
-      sortOrder[optionIndex],
-      optionIndex,
-    ];
+    return this.props.sortOrder.property === checkedProperty;
   }
 
   toggleSort = (property) => {
-    const { sortOrder } = this.props;
-
-    const [option, optionIndex] = this.getSortOption(property);
-
+    const option = this.props.sortOrder;
     const newDirection = option.direction === 'desc' ? 'asc' : 'desc';
-
-    const newSortOrder = Object.assign(
-      [],
-      sortOrder,
-      { [optionIndex]: { ...option, direction: newDirection } },
-    );
+    const newSortOrder = {
+      property,
+      direction: newDirection,
+    };
 
     this.props.onChange(newSortOrder);
   }
 
   renderButton = (property) => {
-    const [option] = this.getSortOption(property);
     const isSorted = this.getIsSorted(property);
-    const color = isSorted ? 'white' : 'primary';
+    const color = isSorted ? 'primary' : 'platinum';
     const label = isSorted ?
-      `${property} ${getDirectionLabel(option.direction)}` :
+      `${property} ${getDirectionLabel(this.props.sortOrder.direction)}` :
       property;
 
     return (
@@ -82,13 +56,13 @@ class SortControl extends Component {
 SortControl.propTypes = {
   onChange: PropTypes.func,
   sortableProperties: PropTypes.array,
-  sortOrder: PropTypes.array,
+  sortOrder: PropTypes.object,
 };
 
 SortControl.defaultProps = {
   onChange: () => {},
   sortableProperties: [],
-  sortOrder: [],
+  sortOrder: {},
 };
 
 export default SortControl;

--- a/src/components/UnorderedList/UnorderedList.js
+++ b/src/components/UnorderedList/UnorderedList.js
@@ -7,13 +7,16 @@ class List extends Component {
     controls: DefaultControls,
     filter: items => items,
     onDelete: () => {},
+    initialSortOrder: {},
   };
 
   constructor(props) {
     super(props);
 
     this.state = {
-      parameters: {},
+      parameters: {
+        sortOrder: this.props.initialSortOrder,
+      },
     };
   }
 
@@ -38,6 +41,7 @@ class List extends Component {
       controls: Controls,
       item: Item,
       sortableProperties,
+      initialSortOrder,
       onDelete,
       children,
       items,
@@ -53,6 +57,7 @@ class List extends Component {
             <Controls
               onChange={this.handleUpdateParameters}
               sortableProperties={sortableProperties}
+              initialSortOrder={initialSortOrder}
             />
           </div>
         )}

--- a/src/components/UnorderedList/__tests__/SortControl.test.js
+++ b/src/components/UnorderedList/__tests__/SortControl.test.js
@@ -7,7 +7,7 @@ import SortControl from '../SortControl';
 const mockProps = {
   onChange: () => {},
   sortableProperties: [],
-  sortOrder: [],
+  sortOrder: {},
 };
 
 describe('<SortControl />', () => {
@@ -35,17 +35,13 @@ describe('<SortControl />', () => {
 
     subject.find('Button').first().simulate('click');
 
-    const expectedValueOfSortOrder = [
-      { direction: 'desc', property: 'foo' },
-    ];
+    const expectedValueOfSortOrder = { direction: 'desc', property: 'foo' };
 
     expect(onChange.mock.calls[0]).toEqual([expectedValueOfSortOrder]);
   });
 
   it('toggles sort order', () => {
-    const startingSortOrder = [
-      { direction: 'desc', property: 'foo' },
-    ];
+    const startingSortOrder = { direction: 'desc', property: 'foo' };
 
     const onChange = jest.fn();
     const subject = shallow((
@@ -59,9 +55,7 @@ describe('<SortControl />', () => {
 
     subject.find('Button').first().simulate('click');
 
-    const nextExpectedValueOfSortOrder = [
-      { direction: 'asc', property: 'foo' },
-    ];
+    const nextExpectedValueOfSortOrder = { direction: 'asc', property: 'foo' };
 
     expect(onChange.mock.calls[0]).toEqual([nextExpectedValueOfSortOrder]);
   });

--- a/src/components/UnorderedList/__tests__/UnorderedList.test.js
+++ b/src/components/UnorderedList/__tests__/UnorderedList.test.js
@@ -61,6 +61,6 @@ describe('<UnorderedList />', () => {
 
     subject.find('MockControls').first().prop('onChange')({ foo: 'bar' });
 
-    expect(subject.state('parameters')).toEqual({ foo: 'bar' });
+    expect(subject.state('parameters')).toMatchObject({ foo: 'bar' });
   });
 });

--- a/src/styles/components/_list.scss
+++ b/src/styles/components/_list.scss
@@ -4,4 +4,5 @@
 @import './list/item';
 @import './list/list';
 @import './list/list-controls';
+@import './list/list-sort-control';
 @import './list/new-button';

--- a/src/styles/components/_overview.scss
+++ b/src/styles/components/_overview.scss
@@ -146,47 +146,4 @@
       margin: 0;
     }
   }
-
-  &.tween-protocol {
-    $transition-before: 500ms;
-    $transition-after: 300ms;
-    $transition-duration: 500ms;
-    $transition-easing: cubic-bezier(.25, .1, .25, 1);
-    transform: translateZ(0);
-    transition: opacity $transition-after $transition-easing;
-
-    .timeline-overview__content {
-      transition: opacity $transition-before $transition-easing;
-    }
-
-    .timeline-overview__panel {
-      transform: translateZ(0);
-      transition: border-radius $transition-duration $transition-easing,
-      transform $transition-duration $transition-easing;
-    }
-
-    &-before {
-      .timeline-overview__content {
-        opacity: 0;
-      }
-    }
-
-    &-active {
-      opacity: .8;
-
-      .timeline-overview__panel {
-        border-radius: unit(3);
-        transform: translate(unit(-4), unit(4));
-      }
-    }
-
-    &-after {
-      opacity: 0;
-
-      .timeline-overview__panel {
-        transform: translate(unit(-4), unit(4)), scale(0, 0);
-      }
-    }
-
-  }
 }

--- a/src/styles/components/_start.scss
+++ b/src/styles/components/_start.scss
@@ -41,11 +41,11 @@
       margin: 0 unit(2) 0 0;
       padding: 1.8em;
       width: unit(30);
+      transition: transform 5s ease-in;
     }
   }
 
   &--hide {
-    opacity: 0;
 
     #create-new-protocol-button {
       transform: translateX(-100%);

--- a/src/styles/components/list/_list-sort-control.scss
+++ b/src/styles/components/list/_list-sort-control.scss
@@ -1,0 +1,10 @@
+.list-sort-control {
+  .button {
+    min-width: 10rem;
+    margin-right: 1rem;
+
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
+}

--- a/src/styles/components/timeline/_stage.scss
+++ b/src/styles/components/timeline/_stage.scss
@@ -6,11 +6,6 @@ $component-name: timeline-stage;
 .#{$component-name} {
   padding: unit(5) 0;
   position: relative;
-  transition: transform var(--animation-duration-fast) var(--animation-easing);
-
-  &:hover {
-    transform: scale(1.2);
-  }
 
   &__notch {
     cursor: pointer;
@@ -35,8 +30,8 @@ $component-name: timeline-stage;
     flex-direction: column;
     align-items: flex-start;
     justify-content: center;
-    transition: opacity var(--animation-duration-standard) var(--animation-easing),
-    transform var(--animation-duration-standard) var(--animation-easing);
+    transition: opacity var(--animation-duration-fast) var(--animation-easing),
+    transform var(--animation-duration-fast) var(--animation-easing);
     opacity: 0;
     transform: translateZ(0) translateX(unit(-10));
   }
@@ -94,6 +89,7 @@ $component-name: timeline-stage;
 
       img {
         max-width: 100%;
+        pointer-events: none;
       }
     }
   }
@@ -102,8 +98,8 @@ $component-name: timeline-stage;
     .#{$component-name}__controls {
       opacity: 1;
       transform: translateX(0);
-      transition: opacity var(--animation-duration-standard) var(--animation-duration-standard) var(--animation-easing),
-      transform var(--animation-duration-standard) var(--animation-duration-standard) var(--animation-easing);
+      transition: opacity var(--animation-duration-fast) var(--animation-duration-fast) var(--animation-easing),
+      transform var(--animation-duration-fast) var(--animation-duration-fast) var(--animation-easing);
     }
   }
 }

--- a/src/styles/components/timeline/_stage.scss
+++ b/src/styles/components/timeline/_stage.scss
@@ -24,7 +24,7 @@ $component-name: timeline-stage;
     position: absolute;
     width: $preview-width;
     top: 0;
-    left: 70rem;
+    left: 75%;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -66,7 +66,6 @@ $component-name: timeline-stage;
   &__screen {
     display: block;
     width: $preview-width;
-    padding-bottom: $preview-width * $preview-ratio;
     position: relative;
     z-index: var(--z-default);
     text-align: center;
@@ -76,15 +75,10 @@ $component-name: timeline-stage;
 
     &-preview {
       width: 100%;
-      height: 100%;
-      position: absolute;
-      z-index: 3;
-      background-color: var(--architect-timeline-screen);
       color: var(--text-light);
       display: flex;
       align-items: center;
       justify-content: center;
-      text-transform: capitalize;
       overflow: hidden;
 
       img {

--- a/src/styles/components/timeline/_stage.scss
+++ b/src/styles/components/timeline/_stage.scss
@@ -1,12 +1,16 @@
-$preview-offset: unit(4);
-$preview-width: 22vw;
+$preview-offset: unit(8);
+$preview-width: 15vw;
 $preview-ratio: 9 / 16;
-$border-width: unit(.3);
 $component-name: timeline-stage;
 
 .#{$component-name} {
   padding: unit(5) 0;
   position: relative;
+  transition: transform var(--animation-duration-fast) var(--animation-easing);
+
+  &:hover {
+    transform: scale(1.2);
+  }
 
   &__notch {
     cursor: pointer;
@@ -25,7 +29,7 @@ $component-name: timeline-stage;
     position: absolute;
     width: $preview-width;
     top: 0;
-    left: calc(50% + #{$preview-offset});
+    left: 70rem;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -34,7 +38,7 @@ $component-name: timeline-stage;
     transition: opacity var(--animation-duration-standard) var(--animation-easing),
     transform var(--animation-duration-standard) var(--animation-easing);
     opacity: 0;
-    transform: translateZ(0) translateX(unit(-4));
+    transform: translateZ(0) translateX(unit(-10));
   }
 
   &__control {
@@ -54,18 +58,13 @@ $component-name: timeline-stage;
   &__edit-stage {
     cursor: pointer;
     position: relative;
-    display: inline-block;
-    width: $preview-width;
-    left: calc(50% - #{$preview-width} - #{$preview-offset});
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     &-title {
-      @include typography('title-5', font-size);
-      text-align: center;
-      color: var(--text);
-      position: absolute;
-      top: 50%;
-      width: 100%;
-      margin: calc(#{-.5 * $preview-width * $preview-ratio} - #{unit(2.5)}) 0 0;
+      margin: 0 0 0 $preview-offset;
+      width: $preview-width;
     }
   }
 
@@ -76,6 +75,9 @@ $component-name: timeline-stage;
     position: relative;
     z-index: var(--z-default);
     text-align: center;
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0.6rem 0.6rem 0 0 var(--architect-panel-shadow);
 
     &-preview {
       width: 100%;
@@ -93,50 +95,6 @@ $component-name: timeline-stage;
       img {
         max-width: 100%;
       }
-    }
-
-    &::before {
-      content: '';
-      display: block;
-      background: var(--architect-shadow);
-      position: absolute;
-      z-index: 2;
-      width: 100%;
-      height: 100%;
-      top: unit(1);
-      left: unit(1);
-    }
-
-    &::after {
-      content: '';
-      display: block;
-      position: absolute;
-      z-index: 4;
-      width: calc(100% + #{$border-width * 2});
-      height: calc(100% + #{$border-width * 2});
-      top: -$border-width;
-      left: -$border-width;
-      border-width: $border-width;
-      border-style: solid;
-      border-color: transparent;
-      transition: border-color var(--animation-easing) var(--animation-duration-standard);
-    }
-
-    &:hover {
-      &::after {
-        border-color: var(--architect-intent);
-      }
-    }
-  }
-
-  &--flip {
-    .#{$component-name}__edit-stage {
-      left: calc(50% + #{$preview-offset});
-    }
-
-    .#{$component-name}__controls {
-      left: calc(50% - #{$preview-width} - #{$preview-offset});
-      transform: translateX(unit(4));
     }
   }
 

--- a/src/styles/components/timeline/_stage.scss
+++ b/src/styles/components/timeline/_stage.scss
@@ -72,7 +72,7 @@ $component-name: timeline-stage;
     text-align: center;
     border-radius: 10px;
     overflow: hidden;
-    box-shadow: 0.6rem 0.6rem 0 0 var(--architect-panel-shadow);
+    box-shadow: .6rem .6rem 0 0 var(--architect-panel-shadow);
 
     &-preview {
       width: 100%;

--- a/src/styles/components/timeline/_timeline.scss
+++ b/src/styles/components/timeline/_timeline.scss
@@ -1,4 +1,4 @@
-$stage-height: (9 / 16) * 22vw;
+$stage-height: (9 / 16) * 15vw;
 $stage-padding: unit(5);
 $bottom-spacing: unit(12);
 


### PR DESCRIPTION
Some in progress edits to the timeline/overview based on user feedback.

- [x] Single column (remove alternate left/right)
- [x] Add automatic numbering to stage ordering.

One additional change:

- Make variable sorting only apply to one attribute at a time, and add the variable type as a sortable attribute.