### PR TITLE
Fix protocol control buttons

### DIFF
--- a/src/components/ControlBar.js
+++ b/src/components/ControlBar.js
@@ -39,8 +39,8 @@ const ControlBar = ({ buttons, secondaryButtons, flip, show, className }) => {
 };
 
 ControlBar.propTypes = {
-  buttons: PropTypes.node,
-  secondaryButtons: PropTypes.node,
+  buttons: PropTypes.arrayOf(PropTypes.node),
+  secondaryButtons: PropTypes.arrayOf(PropTypes.node),
   className: PropTypes.string,
   show: PropTypes.bool,
   flip: PropTypes.bool,

--- a/src/components/ProtocolControlBar.js
+++ b/src/components/ProtocolControlBar.js
@@ -17,7 +17,7 @@ const ProtocolControlBar = ({
 }) => (
   <ControlBar
     show={show && hasUnsavedChanges}
-    buttons={(
+    buttons={[
       <Button
         onClick={saveProtocol}
         color="white"
@@ -26,8 +26,8 @@ const ProtocolControlBar = ({
         disabled={!hasAnyStages}
       >
         Save
-      </Button>
-    )}
+      </Button>,
+    ]}
   />
 );
 

--- a/src/components/__tests__/__snapshots__/ProtocolControlBar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProtocolControlBar.test.js.snap
@@ -22,41 +22,8 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
-      "buttons": <Button
-        color="white"
-        content=""
-        disabled={true}
-        icon={
-          <Icon
-            className=""
-            color=""
-            name="arrow-right"
-            style={Object {}}
-          />
-        }
-        iconPosition="right"
-        onClick={[Function]}
-        size=""
-        type="button"
-      >
-        Save
-      </Button>,
-      "className": "",
-      "flip": false,
-      "secondaryButtons": null,
-      "show": false,
-    },
-    "ref": null,
-    "rendered": null,
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "buttons": <Button
+      "buttons": Array [
+        <Button
           color="white"
           content=""
           disabled={true}
@@ -75,6 +42,43 @@ ShallowWrapper {
         >
           Save
         </Button>,
+      ],
+      "className": "",
+      "flip": false,
+      "secondaryButtons": null,
+      "show": false,
+    },
+    "ref": null,
+    "rendered": null,
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "buttons": Array [
+          <Button
+            color="white"
+            content=""
+            disabled={true}
+            icon={
+              <Icon
+                className=""
+                color=""
+                name="arrow-right"
+                style={Object {}}
+              />
+            }
+            iconPosition="right"
+            onClick={[Function]}
+            size=""
+            type="button"
+          >
+            Save
+          </Button>,
+        ],
         "className": "",
         "flip": false,
         "secondaryButtons": null,


### PR DESCRIPTION
On master, I'm unable to save a protocol. ControlBar expects an array of buttons; the protocol save button doesn't render.

We could instead accept a `node` propType and convert to arrays, but single-element arrays are already used elsewhere, so I opted for this route.
