### PR TITLE
Support for editing Narrative Interface

### DIFF
--- a/src/components/EditableList/withEditHandlers.js
+++ b/src/components/EditableList/withEditHandlers.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import uuid from 'uuid';
 import {
   compose,
+  defaultProps,
   withHandlers,
 } from 'recompose';
 import { get } from 'lodash';
@@ -49,9 +50,10 @@ const handlers = withHandlers({
     upsert,
     setEditField,
     editField,
+    normalize,
   }) =>
     (value) => {
-      upsert(editField, value);
+      upsert(editField, normalize(value));
       setImmediate(() => {
         setEditField();
       });
@@ -59,6 +61,9 @@ const handlers = withHandlers({
 });
 
 const withEditHandlers = compose(
+  defaultProps({
+    normalize: value => value,
+  }),
   connect(mapStateToProps, mapDispatchToProps),
   handlers,
 );

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -85,6 +85,7 @@ const Editor = ({
                 <Component form={form} {...rest} />
               }
             </Form>
+            <div className="editor__spacer" />
           </div>
           <Issues
             issues={issues}

--- a/src/components/StageEditor/Interfaces/Narrative.js
+++ b/src/components/StageEditor/Interfaces/Narrative.js
@@ -1,0 +1,17 @@
+import Name from '../sections/Name';
+import NodeType from '../sections/NodeType';
+import NarrativePresets from '../sections/NarrativePresets';
+import Background from '../sections/Background';
+import NarrativeBehaviours from '../sections/NarrativeBehaviours';
+
+const Narrative = {
+  sections: [
+    Name,
+    NodeType,
+    NarrativePresets,
+    Background,
+    NarrativeBehaviours,
+  ],
+};
+
+export default Narrative;

--- a/src/components/StageEditor/Interfaces/index.js
+++ b/src/components/StageEditor/Interfaces/index.js
@@ -8,6 +8,7 @@ import Sociogram from './Sociogram';
 import CategoricalBin from './CategoricalBin';
 import OrdinalBin from './OrdinalBin';
 import PerAlterForm from './PerAlterForm';
+import Narrative from './Narrative';
 
 const interfaces = {
   Information,
@@ -18,6 +19,7 @@ const interfaces = {
   CategoricalBin,
   OrdinalBin,
   PerAlterForm,
+  Narrative,
 };
 
 const emptyInterface = {

--- a/src/components/StageEditor/StageEditor.js
+++ b/src/components/StageEditor/StageEditor.js
@@ -12,6 +12,7 @@ const INTERFACE_NAMES = {
   NameGeneratorList: 'Roster Name Generator (list)',
   NameGeneratorAutoComplete: 'Roster Name Generator (search)',
   Sociogram: 'Sociogram',
+  Narrative: 'Narrative',
 };
 
 const getInterfaceName = type => INTERFACE_NAMES[type] || type;

--- a/src/components/StageEditor/sections/Background.js
+++ b/src/components/StageEditor/sections/Background.js
@@ -28,7 +28,7 @@ class Background extends React.Component {
     const { backgroundType } = this.state;
 
     return (
-      <Guidance contentId="guidance.editor.sociogram.background">
+      <Guidance contentId="guidance.editor.background">
         <div className="stage-editor-section">
           <Row>
             <h3>Background</h3>

--- a/src/components/StageEditor/sections/NarrativeBehaviours.js
+++ b/src/components/StageEditor/sections/NarrativeBehaviours.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Guidance from '../../Guidance';
+import { ValidatedField } from '../../../components/Form';
+import * as Fields from '../../../ui/components/Fields';
+import { getFieldId } from '../../../utils/issues';
+
+// "freeDraw": true,
+// "allowRepositioning": true
+
+const NarrativeBehaviours = () => (
+  <Guidance contentId="guidance.editor.name">
+    <div className="stage-editor-section">
+      <div id={getFieldId('freeDraw')} data-name="Free draw" />
+      <h2>Free-draw</h2>
+      <ValidatedField
+        name="freeDraw"
+        label="Allow drawing on the canvas."
+        component={Fields.Checkbox}
+      />
+
+      <div id={getFieldId('allowRepositioning')} data-name="Allow repositioning" />
+      <h2>Allow repositioning</h2>
+      <ValidatedField
+        name="allowRepositioning"
+        label="Allow repositioning of nodes."
+        component={Fields.Checkbox}
+      />
+    </div>
+  </Guidance>
+);
+
+export default NarrativeBehaviours;

--- a/src/components/StageEditor/sections/NarrativeBehaviours.js
+++ b/src/components/StageEditor/sections/NarrativeBehaviours.js
@@ -13,7 +13,7 @@ const NarrativeBehaviours = () => (
         <div id={getFieldId('freeDraw')} data-name="Free draw" />
         <h4>Free-draw</h4>
         <ValidatedField
-          name="behaviours.freeDraw"
+          name="freeDraw"
           label="Allow drawing on the canvas."
           component={Fields.Checkbox}
         />
@@ -21,7 +21,7 @@ const NarrativeBehaviours = () => (
         <div id={getFieldId('allowRepositioning')} data-name="Allow repositioning" />
         <h4>Allow repositioning</h4>
         <ValidatedField
-          name="behaviours.allowRepositioning"
+          name="allowRepositioning"
           label="Allow repositioning of nodes."
           component={Fields.Checkbox}
         />

--- a/src/components/StageEditor/sections/NarrativeBehaviours.js
+++ b/src/components/StageEditor/sections/NarrativeBehaviours.js
@@ -6,11 +6,12 @@ import * as Fields from '../../../ui/components/Fields';
 import { getFieldId } from '../../../utils/issues';
 
 const NarrativeBehaviours = () => (
-  <Guidance contentId="guidance.editor.name">
+  <Guidance contentId="guidance.editor.narrative_behaviours">
     <div className="stage-editor-section">
+      <h2>Narrative Behaviours</h2>
       <FormSection name="behaviours">
         <div id={getFieldId('freeDraw')} data-name="Free draw" />
-        <h2>Free-draw</h2>
+        <h4>Free-draw</h4>
         <ValidatedField
           name="behaviours.freeDraw"
           label="Allow drawing on the canvas."
@@ -18,7 +19,7 @@ const NarrativeBehaviours = () => (
         />
 
         <div id={getFieldId('allowRepositioning')} data-name="Allow repositioning" />
-        <h2>Allow repositioning</h2>
+        <h4>Allow repositioning</h4>
         <ValidatedField
           name="behaviours.allowRepositioning"
           label="Allow repositioning of nodes."

--- a/src/components/StageEditor/sections/NarrativeBehaviours.js
+++ b/src/components/StageEditor/sections/NarrativeBehaviours.js
@@ -1,30 +1,30 @@
 import React from 'react';
+import { FormSection } from 'redux-form';
 import Guidance from '../../Guidance';
 import { ValidatedField } from '../../../components/Form';
 import * as Fields from '../../../ui/components/Fields';
 import { getFieldId } from '../../../utils/issues';
 
-// "freeDraw": true,
-// "allowRepositioning": true
-
 const NarrativeBehaviours = () => (
   <Guidance contentId="guidance.editor.name">
     <div className="stage-editor-section">
-      <div id={getFieldId('freeDraw')} data-name="Free draw" />
-      <h2>Free-draw</h2>
-      <ValidatedField
-        name="freeDraw"
-        label="Allow drawing on the canvas."
-        component={Fields.Checkbox}
-      />
+      <FormSection name="behaviours">
+        <div id={getFieldId('freeDraw')} data-name="Free draw" />
+        <h2>Free-draw</h2>
+        <ValidatedField
+          name="behaviours.freeDraw"
+          label="Allow drawing on the canvas."
+          component={Fields.Checkbox}
+        />
 
-      <div id={getFieldId('allowRepositioning')} data-name="Allow repositioning" />
-      <h2>Allow repositioning</h2>
-      <ValidatedField
-        name="allowRepositioning"
-        label="Allow repositioning of nodes."
-        component={Fields.Checkbox}
-      />
+        <div id={getFieldId('allowRepositioning')} data-name="Allow repositioning" />
+        <h2>Allow repositioning</h2>
+        <ValidatedField
+          name="behaviours.allowRepositioning"
+          label="Allow repositioning of nodes."
+          component={Fields.Checkbox}
+        />
+      </FormSection>
     </div>
   </Guidance>
 );

--- a/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
+++ b/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { withProps, compose } from 'recompose';
+import { omit, isEmpty } from 'lodash';
 import PresetPreview from './PresetPreview';
 import PresetFields from './PresetFields';
 import EditableList, { withSubjectNodeType } from '../../../EditableList';
@@ -13,6 +14,13 @@ const narrativePresetTemplate = {
   highlight: [],
 };
 
+const normalizePreset = (values) => {
+  if (!isEmpty(values.groupVariable)) {
+    return omit(values, ['groupVariable']);
+  }
+  return values;
+};
+
 const NarrativePresets = props => (
   <EditableList
     contentId="guidance.editor.narrative_presets"
@@ -21,6 +29,7 @@ const NarrativePresets = props => (
     title="Edit Preset"
     fieldName="presets"
     template={narrativePresetTemplate}
+    normalize={normalizePreset}
     {...props}
   >
     <h2>Narrative Presets</h2>

--- a/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
+++ b/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
@@ -6,7 +6,7 @@ import EditableList, { withSubjectNodeType } from '../../../EditableList';
 
 const narrativePresetTemplate = {
   layoutVariable: null,
-  // groupVariable: null, // TODO: How does NC handle this for empty value?
+  groupVariable: null,
   edges: {
     display: [],
   },

--- a/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
+++ b/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { withProps, compose } from 'recompose';
+import PresetPreview from './PresetPreview';
+import PresetFields from './PresetFields';
+import EditableList, { withSubjectNodeType } from '../../../EditableList';
+
+const NarrativePresets = props => (
+  <EditableList
+    contentId="guidance.editor.narrative_presets"
+    previewComponent={PresetPreview}
+    editComponent={PresetFields}
+    title="Edit Preset"
+    fieldName="presets"
+    {...props}
+  >
+    <h2>Narrative Presets</h2>
+    <p>
+      Add one or more &quot;presets&quot; below, to ecourage lines of discourse with participants.
+    </p>
+  </EditableList>
+);
+
+export { NarrativePresets };
+
+export default compose(
+  withSubjectNodeType,
+  withProps(({ nodeType }) => ({ disabled: !nodeType })),
+)(NarrativePresets);

--- a/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
+++ b/src/components/StageEditor/sections/NarrativePresets/NarrativePresets.js
@@ -4,6 +4,15 @@ import PresetPreview from './PresetPreview';
 import PresetFields from './PresetFields';
 import EditableList, { withSubjectNodeType } from '../../../EditableList';
 
+const narrativePresetTemplate = {
+  layoutVariable: null,
+  // groupVariable: null, // TODO: How does NC handle this for empty value?
+  edges: {
+    display: [],
+  },
+  highlight: [],
+};
+
 const NarrativePresets = props => (
   <EditableList
     contentId="guidance.editor.narrative_presets"
@@ -11,6 +20,7 @@ const NarrativePresets = props => (
     editComponent={PresetFields}
     title="Edit Preset"
     fieldName="presets"
+    template={narrativePresetTemplate}
     {...props}
   >
     <h2>Narrative Presets</h2>

--- a/src/components/StageEditor/sections/NarrativePresets/PresetFields.js
+++ b/src/components/StageEditor/sections/NarrativePresets/PresetFields.js
@@ -9,14 +9,15 @@ import { ValidatedField } from '../../../Form';
 import * as ArchitectFields from '../../../Form/Fields';
 import * as Fields from '../../../../ui/components/Fields';
 import { Row } from '../../../OrderedList';
+import withOptionsForPreset from './withOptionsForPreset';
 
 class PresetFields extends Component {
   render() {
     const {
       layoutVariblesForNodeType,
-      groupVariblesForNodeType,
+      groupVariablesForNodeType,
       edgesForNodeType,
-      highlightableForNodeType,
+      highlightVariablesForNodeType,
     } = this.props;
 
     return (
@@ -38,21 +39,16 @@ class PresetFields extends Component {
             label="Layout variable"
             placeholder="&mdash; Select a layout variable &mdash;"
             validation={{ required: true }}
-            options={layoutVariblesForNodeType.map(([variableId, meta]) => (
-              { value: variableId, label: meta.label }
-            ))}
+            options={layoutVariblesForNodeType}
           />
         </Row>
         <Row>
           <ValidatedField
             name="groupVariable"
             component={ArchitectFields.Select}
-            label="Layout variable"
+            label="Group variable"
             placeholder="&mdash; Select a group variable &mdash;"
-            validation={{ required: true }}
-            options={groupVariblesForNodeType.map(([variableId, meta]) => (
-              { value: variableId, label: meta.label }
-            ))}
+            options={groupVariablesForNodeType}
           />
         </Row>
         <Row>
@@ -61,9 +57,7 @@ class PresetFields extends Component {
             component={Fields.CheckboxGroup}
             label="Display the following edges:"
             placeholder="&mdash; Toggle an edge to display &mdash;"
-            options={edgesForNodeType.map(([variableName, meta]) => (
-              { value: variableName, label: meta.label }
-            ))}
+            options={edgesForNodeType}
           />
         </Row>
         <Row>
@@ -72,9 +66,7 @@ class PresetFields extends Component {
             component={Fields.CheckboxGroup}
             label="Highlight nodes with the following attribute:"
             placeholder="&mdash; Toggle a variable to highlight &mdash;"
-            options={highlightableForNodeType.map(([variableName, meta]) => (
-              { value: variableName, label: meta.label }
-            ))}
+            options={highlightVariablesForNodeType}
           />
         </Row>
       </React.Fragment>
@@ -84,18 +76,18 @@ class PresetFields extends Component {
 
 PresetFields.propTypes = {
   layoutVariblesForNodeType: PropTypes.array,
-  groupVariblesForNodeType: PropTypes.array,
+  groupVariablesForNodeType: PropTypes.array,
   edgesForNodeType: PropTypes.array,
-  highlightableForNodeType: PropTypes.array,
+  highlightVariablesForNodeType: PropTypes.array,
 };
 
 PresetFields.defaultProps = {
   layoutVariblesForNodeType: [],
-  groupVariblesForNodeType: [],
+  groupVariablesForNodeType: [],
   edgesForNodeType: [],
-  highlightableForNodeType: [],
+  highlightVariablesForNodeType: [],
 };
 
 export { PresetFields };
 
-export default PresetFields;
+export default withOptionsForPreset(PresetFields);

--- a/src/components/StageEditor/sections/NarrativePresets/PresetFields.js
+++ b/src/components/StageEditor/sections/NarrativePresets/PresetFields.js
@@ -1,0 +1,101 @@
+/* eslint-disable react/prefer-stateless-function */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Field,
+} from 'redux-form';
+import { getFieldId } from '../../../../utils/issues';
+import { ValidatedField } from '../../../Form';
+import * as ArchitectFields from '../../../Form/Fields';
+import * as Fields from '../../../../ui/components/Fields';
+import { Row } from '../../../OrderedList';
+
+class PresetFields extends Component {
+  render() {
+    const {
+      layoutVariblesForNodeType,
+      groupVariblesForNodeType,
+      edgesForNodeType,
+      highlightableForNodeType,
+    } = this.props;
+
+    return (
+      <React.Fragment>
+        <Row>
+          <h3 id={getFieldId('text')}>Preset label</h3>
+          <ValidatedField
+            name="label"
+            component={Fields.Text}
+            label=""
+            placeholder="Enter a label for the preset here"
+            validation={{ required: true }}
+          />
+        </Row>
+        <Row>
+          <ValidatedField
+            name="layoutVariable"
+            component={ArchitectFields.Select}
+            label="Layout variable"
+            placeholder="&mdash; Select a layout variable &mdash;"
+            validation={{ required: true }}
+            options={layoutVariblesForNodeType.map(([variableId, meta]) => (
+              { value: variableId, label: meta.label }
+            ))}
+          />
+        </Row>
+        <Row>
+          <ValidatedField
+            name="groupVariable"
+            component={ArchitectFields.Select}
+            label="Layout variable"
+            placeholder="&mdash; Select a group variable &mdash;"
+            validation={{ required: true }}
+            options={groupVariblesForNodeType.map(([variableId, meta]) => (
+              { value: variableId, label: meta.label }
+            ))}
+          />
+        </Row>
+        <Row>
+          <Field
+            name="edges.display"
+            component={Fields.CheckboxGroup}
+            label="Display the following edges:"
+            placeholder="&mdash; Toggle an edge to display &mdash;"
+            options={edgesForNodeType.map(([variableName, meta]) => (
+              { value: variableName, label: meta.label }
+            ))}
+          />
+        </Row>
+        <Row>
+          <Field
+            name="highlight"
+            component={Fields.CheckboxGroup}
+            label="Highlight nodes with the following attribute:"
+            placeholder="&mdash; Toggle a variable to highlight &mdash;"
+            options={highlightableForNodeType.map(([variableName, meta]) => (
+              { value: variableName, label: meta.label }
+            ))}
+          />
+        </Row>
+      </React.Fragment>
+    );
+  }
+}
+
+PresetFields.propTypes = {
+  layoutVariblesForNodeType: PropTypes.array,
+  groupVariblesForNodeType: PropTypes.array,
+  edgesForNodeType: PropTypes.array,
+  highlightableForNodeType: PropTypes.array,
+};
+
+PresetFields.defaultProps = {
+  layoutVariblesForNodeType: [],
+  groupVariblesForNodeType: [],
+  edgesForNodeType: [],
+  highlightableForNodeType: [],
+};
+
+export { PresetFields };
+
+export default PresetFields;

--- a/src/components/StageEditor/sections/NarrativePresets/PresetFields.js
+++ b/src/components/StageEditor/sections/NarrativePresets/PresetFields.js
@@ -1,9 +1,8 @@
 /* eslint-disable react/prefer-stateless-function */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Field,
-} from 'redux-form';
+import { compose } from 'recompose';
+import { Field } from 'redux-form';
 import { getFieldId } from '../../../../utils/issues';
 import { ValidatedField } from '../../../Form';
 import * as ArchitectFields from '../../../Form/Fields';
@@ -47,7 +46,6 @@ class PresetFields extends Component {
             name="groupVariable"
             component={ArchitectFields.Select}
             label="Group variable"
-            placeholder="&mdash; Select a group variable &mdash;"
             options={groupVariablesForNodeType}
           />
         </Row>
@@ -90,4 +88,7 @@ PresetFields.defaultProps = {
 
 export { PresetFields };
 
-export default withOptionsForPreset(PresetFields);
+export default compose(
+  withOptionsForPreset,
+  // withChangeGroupVariableHandler,
+)(PresetFields);

--- a/src/components/StageEditor/sections/NarrativePresets/PresetPreview.js
+++ b/src/components/StageEditor/sections/NarrativePresets/PresetPreview.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
+import { Field } from 'redux-form';
+import Preview from '../../../EditableList/Preview';
+
+class PresetPreview extends Preview {
+  preview() {
+    const fieldId = this.props.fieldId;
+
+    return (
+      <Field
+        name={`${fieldId}.label`}
+        component={field => <Markdown source={field.input.value} />}
+      />
+    );
+  }
+}
+
+PresetPreview.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+};
+
+export { PresetPreview };
+
+export default PresetPreview;

--- a/src/components/StageEditor/sections/NarrativePresets/__tests__/selectors.test.js
+++ b/src/components/StageEditor/sections/NarrativePresets/__tests__/selectors.test.js
@@ -1,0 +1,88 @@
+/* eslint-env jest */
+import {
+  getLayoutVariablesForNodeType,
+  getHighlightVariablesForNodeType,
+  getGroupVariablesForNodeType,
+  getEdgesForNodeType,
+} from '../selectors';
+
+const nodeType = '1234-1234-1234';
+
+const mockVariableRegistry = {
+  node: {
+    [nodeType]: {
+      variables: {
+        '1234-1234-1': {
+          label: 'my layout',
+          type: 'layout',
+        },
+        '1234-1234-2': {
+          label: 'my category',
+          type: 'categorical',
+        },
+        '1234-1234-3': {
+          label: 'my boolean',
+          type: 'boolean',
+        },
+      },
+    },
+  },
+  edge: {
+    '1234-5': {
+      label: 'an edge',
+      color: 'blue',
+    },
+  },
+};
+
+const mockState = {
+  protocol: {
+    present: {
+      variableRegistry: mockVariableRegistry,
+    },
+  },
+};
+
+describe('NarrativePresets', () => {
+  describe('selectors', () => {
+    it('get layout variables for node type', () => {
+      const result = getLayoutVariablesForNodeType(mockState, { nodeType });
+
+      expect(result).toEqual([{
+        value: '1234-1234-1',
+        label: 'my layout',
+        color: '',
+      }]);
+    });
+
+    it('get highlight variables for node type', () => {
+      const result = getHighlightVariablesForNodeType(mockState, { nodeType });
+
+      expect(result).toEqual([{
+        value: '1234-1234-3',
+        label: 'my boolean',
+        color: '',
+      }]);
+    });
+
+    it('get group variables for node type', () => {
+      const result = getGroupVariablesForNodeType(mockState, { nodeType });
+
+      expect(result).toEqual([{
+        value: '1234-1234-2',
+        label: 'my category',
+        color: '',
+      }]);
+    });
+
+    it('get edges for node type', () => {
+      const result = getEdgesForNodeType(mockState, { nodeType });
+
+      expect(result).toEqual([{
+        value: '1234-5',
+        label: 'an edge',
+        color: 'blue',
+      }]);
+    });
+  });
+});

--- a/src/components/StageEditor/sections/NarrativePresets/__tests__/selectors.test.js
+++ b/src/components/StageEditor/sections/NarrativePresets/__tests__/selectors.test.js
@@ -8,7 +8,7 @@ import {
 
 const nodeType = '1234-1234-1234';
 
-const mockVariableRegistry = {
+const mockCodebook = {
   node: {
     [nodeType]: {
       variables: {
@@ -38,7 +38,7 @@ const mockVariableRegistry = {
 const mockState = {
   protocol: {
     present: {
-      variableRegistry: mockVariableRegistry,
+      codebook: mockCodebook,
     },
   },
 };

--- a/src/components/StageEditor/sections/NarrativePresets/__tests__/selectors.test.js
+++ b/src/components/StageEditor/sections/NarrativePresets/__tests__/selectors.test.js
@@ -13,15 +13,15 @@ const mockCodebook = {
     [nodeType]: {
       variables: {
         '1234-1234-1': {
-          label: 'my layout',
+          name: 'my layout',
           type: 'layout',
         },
         '1234-1234-2': {
-          label: 'my category',
+          name: 'my category',
           type: 'categorical',
         },
         '1234-1234-3': {
-          label: 'my boolean',
+          name: 'my boolean',
           type: 'boolean',
         },
       },
@@ -29,7 +29,7 @@ const mockCodebook = {
   },
   edge: {
     '1234-5': {
-      label: 'an edge',
+      name: 'an edge',
       color: 'blue',
     },
   },
@@ -68,11 +68,17 @@ describe('NarrativePresets', () => {
     it('get group variables for node type', () => {
       const result = getGroupVariablesForNodeType(mockState, { nodeType });
 
-      expect(result).toEqual([{
-        value: '1234-1234-2',
-        label: 'my category',
-        color: '',
-      }]);
+      expect(result).toEqual([
+        {
+          value: '',
+          label: '\u2014 None \u2014',
+        },
+        {
+          value: '1234-1234-2',
+          label: 'my category',
+          color: '',
+        },
+      ]);
     });
 
     it('get edges for node type', () => {

--- a/src/components/StageEditor/sections/NarrativePresets/index.js
+++ b/src/components/StageEditor/sections/NarrativePresets/index.js
@@ -1,0 +1,2 @@
+export { default } from './NarrativePresets';
+export { default as PresetPreview } from './PresetPreview';

--- a/src/components/StageEditor/sections/NarrativePresets/selectors.js
+++ b/src/components/StageEditor/sections/NarrativePresets/selectors.js
@@ -1,10 +1,10 @@
 import { get, map, reduce } from 'lodash';
-import { getVariableRegistry } from '../../../../selectors/protocol';
+import { getCodebook } from '../../../../selectors/protocol';
 
 export const getVariablesForNodeType = (state, props) => {
   const nodeType = props.nodeType;
-  const variableRegistry = getVariableRegistry(state);
-  return get(variableRegistry, ['node', nodeType, 'variables'], {});
+  const codebook = getCodebook(state);
+  return get(codebook, ['node', nodeType, 'variables'], {});
 };
 
 const asOption = (value, key) =>
@@ -54,7 +54,7 @@ export const getGroupVariablesForNodeType = (state, props) => {
 };
 
 export const getEdgesForNodeType = (state) => {
-  const variableRegistry = getVariableRegistry(state);
+  const codebook = getCodebook(state);
 
-  return map(variableRegistry.edge, asOption);
+  return map(codebook.edge, asOption);
 };

--- a/src/components/StageEditor/sections/NarrativePresets/selectors.js
+++ b/src/components/StageEditor/sections/NarrativePresets/selectors.js
@@ -1,6 +1,7 @@
 import { get, map, reduce } from 'lodash';
 import { getCodebook } from '../../../../selectors/protocol';
 
+// TODO: refactor this to use new selector
 export const getVariablesForNodeType = (state, props) => {
   const nodeType = props.nodeType;
   const codebook = getCodebook(state);
@@ -9,7 +10,7 @@ export const getVariablesForNodeType = (state, props) => {
 
 const asOption = (value, key) =>
   ({
-    label: get(value, 'label', ''),
+    label: get(value, 'name', ''),
     value: key,
     color: get(value, 'color', ''),
   });
@@ -46,11 +47,13 @@ export const getHighlightVariablesForNodeType = (state, props) => {
 export const getGroupVariablesForNodeType = (state, props) => {
   const variables = getVariablesForNodeType(state, props);
 
-  return reduce(
+  const options = reduce(
     variables,
     filterAsOption(item => item.type === 'categorical'),
-    [],
+    [{ label: '\u2014 None \u2014', value: '' }],
   );
+
+  return options;
 };
 
 export const getEdgesForNodeType = (state) => {

--- a/src/components/StageEditor/sections/NarrativePresets/selectors.js
+++ b/src/components/StageEditor/sections/NarrativePresets/selectors.js
@@ -1,0 +1,60 @@
+import { get, map, reduce } from 'lodash';
+import { getVariableRegistry } from '../../../../selectors/protocol';
+
+export const getVariablesForNodeType = (state, props) => {
+  const nodeType = props.nodeType;
+  const variableRegistry = getVariableRegistry(state);
+  return get(variableRegistry, ['node', nodeType, 'variables'], {});
+};
+
+const asOption = (value, key) =>
+  ({
+    label: get(value, 'label', ''),
+    value: key,
+    color: get(value, 'color', ''),
+  });
+
+const filterAsOption = rule =>
+  (memo, item, id) => {
+    if (!rule(item)) { return memo; }
+    return [
+      ...memo,
+      asOption(item, id),
+    ];
+  };
+
+export const getLayoutVariablesForNodeType = (state, props) => {
+  const variables = getVariablesForNodeType(state, props);
+
+  return reduce(
+    variables,
+    filterAsOption(item => item.type === 'layout'),
+    [],
+  );
+};
+
+export const getHighlightVariablesForNodeType = (state, props) => {
+  const variables = getVariablesForNodeType(state, props);
+
+  return reduce(
+    variables,
+    filterAsOption(item => item.type === 'boolean'),
+    [],
+  );
+};
+
+export const getGroupVariablesForNodeType = (state, props) => {
+  const variables = getVariablesForNodeType(state, props);
+
+  return reduce(
+    variables,
+    filterAsOption(item => item.type === 'categorical'),
+    [],
+  );
+};
+
+export const getEdgesForNodeType = (state) => {
+  const variableRegistry = getVariableRegistry(state);
+
+  return map(variableRegistry.edge, asOption);
+};

--- a/src/components/StageEditor/sections/NarrativePresets/withOptionsForPreset.js
+++ b/src/components/StageEditor/sections/NarrativePresets/withOptionsForPreset.js
@@ -1,0 +1,26 @@
+import { connect } from 'react-redux';
+import {
+  getLayoutVariablesForNodeType,
+  getHighlightVariablesForNodeType,
+  getGroupVariablesForNodeType,
+  getEdgesForNodeType,
+} from './selectors';
+
+
+const mapStateToProps = (state, props) => {
+  const layoutVariblesForNodeType = getLayoutVariablesForNodeType(state, props);
+  const highlightVariablesForNodeType = getHighlightVariablesForNodeType(state, props);
+  const groupVariablesForNodeType = getGroupVariablesForNodeType(state, props);
+  const edgesForNodeType = getEdgesForNodeType(state, props);
+
+  return {
+    layoutVariblesForNodeType,
+    highlightVariablesForNodeType,
+    groupVariablesForNodeType,
+    edgesForNodeType,
+  };
+};
+
+const withOptionsForPreset = connect(mapStateToProps);
+
+export default withOptionsForPreset;

--- a/src/components/Timeline/InsertStage/interfaceOptions.js
+++ b/src/components/Timeline/InsertStage/interfaceOptions.js
@@ -97,4 +97,17 @@ export default [
       ),
     },
   },
+  {
+    type: 'Narrative',
+    title: 'Narrative',
+    guidance: {
+      description: (
+        <p>
+          The Narrative Interface is used to guide a conversation with a participants.
+          It does not modify the participant network. You are expected to use your own
+          audio/visual recording equipment.
+        </p>
+      ),
+    },
+  },
 ];

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -118,10 +118,16 @@ export default {
       <p>guidance.editor.sociogram_prompt.layout</p>
     </Fragment>
   ),
-  'guidance.editor.sociogram.background': (
+  'guidance.editor.background': (
     <Fragment>
-      <h3>Sociogram Background</h3>
-      <p>guidance.editor.sociogram.background</p>
+      <h3>Background</h3>
+      <p>guidance.editor.background</p>
+    </Fragment>
+  ),
+  'guidance.editor.narrative_behaviours': (
+    <Fragment>
+      <h3>Narrative Behaviours</h3>
+      <p>guidance.editor.narrative_behaviours</p>
     </Fragment>
   ),
   'guidance.editor.sociogram_prompt.edges': (

--- a/src/styles/shared/_editor.scss
+++ b/src/styles/shared/_editor.scss
@@ -24,6 +24,10 @@
     width: 100%;
   }
 
+  &__spacer {
+    height: 100px;
+  }
+
   &__subsection {
     margin: unit(2) 0 0;
 


### PR DESCRIPTION
New narrative interface editing capability.

## Known issues
- [ ] In presets, what should the spec be for empty values, omission? Currently values are templated as:

  ```
  const narrativePresetTemplate = {
    layoutVariable: null,
    groupVariable: null, // When left empty, this is set to "" - do we need to clear it?
    edges: {
      display: [],
    },
    highlight: [],
  };
  ```
- [ ] Guidance text needs to be set for new interface sections.

Resolves: https://github.com/codaco/Architect/issues/287