### PR TITLE
Only add saved protocols to history

### DIFF
--- a/src/ducks/modules/__tests__/recentProtocols.test.js
+++ b/src/ducks/modules/__tests__/recentProtocols.test.js
@@ -4,6 +4,7 @@ import { createStore } from 'redux';
 import fs from 'fs';
 import { actionCreators as loadActions } from '../protocols/load';
 import { actionCreators as exportActions } from '../protocols/export';
+import { actionCreators as importActions } from '../protocols/import';
 import reducer, { actionCreators } from '../recentProtocols';
 
 describe('recentProtocols', () => {
@@ -50,6 +51,22 @@ describe('recentProtocols', () => {
       });
 
       store.dispatch(exportActions.exportProtocolSuccess('/dev/null/mock/recent/path/2'));
+    });
+
+    it('IMPORT_PROTOCOL_SUCCESS adds to recentProtocolsList', (done) => {
+      store.dispatch(importActions.importProtocolSuccess({ filePath: '/dev/null/mock/recent/path/1' }));
+
+      store.subscribe(() => {
+        const state = store.getState();
+
+        expect(state.length).toBe(2);
+        expect(state[0]).toMatchObject({ filePath: '/dev/null/mock/recent/path/2' });
+        expect(state[1]).toMatchObject({ filePath: '/dev/null/mock/recent/path/1' });
+
+        done();
+      });
+
+      store.dispatch(importActions.importProtocolSuccess({ filePath: '/dev/null/mock/recent/path/2' }));
     });
 
     it('CLEAR_DEAD_LINKS', (done) => {

--- a/src/ducks/modules/protocols/export.js
+++ b/src/ducks/modules/protocols/export.js
@@ -36,6 +36,7 @@ const exportProtocolThunk = () =>
 
 const actionCreators = {
   exportProtocol: exportProtocolThunk,
+  exportProtocolSuccess,
 };
 
 const actionTypes = {

--- a/src/ducks/modules/recentProtocols.js
+++ b/src/ducks/modules/recentProtocols.js
@@ -1,11 +1,8 @@
 import { existsSync } from 'fs';
 import { uniqBy } from 'lodash';
-import {
-  actionTypes as loadActions,
-} from './protocols/load';
-import {
-  actionTypes as exportActions,
-} from './protocols/export';
+import { actionTypes as loadActionTypes } from './protocols/load';
+import { actionTypes as exportActionTypes } from './protocols/export';
+import { actionTypes as importActionTypes } from './protocols/import';
 
 const protocolExists = ({ filePath }) => existsSync(filePath);
 
@@ -19,7 +16,7 @@ const initialState = [];
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
-    case loadActions.LOAD_PROTOCOL_SUCCESS: {
+    case loadActionTypes.LOAD_PROTOCOL_SUCCESS:
       return state.map((protocol) => {
         if (protocol.filePath !== action.meta.filePath) { return protocol; }
 
@@ -28,14 +25,13 @@ export default function reducer(state = initialState, action = {}) {
           lastOpened: new Date().getTime(),
         };
       }).sort((a, b) => a.lastOpened < b.lastOpened);
-    }
-    case exportActions.EXPORT_PROTOCOL_SUCCESS: {
+    case importActionTypes.IMPORT_PROTOCOL_SUCCESS:
+    case exportActionTypes.EXPORT_PROTOCOL_SUCCESS:
       return uniqBy([
         { filePath: action.filePath, lastOpened: new Date().getTime() },
         ...state,
       ], 'filePath')
         .slice(0, 50);
-    }
     case CLEAR_DEAD_LINKS:
       return state.filter(protocolExists);
     default:

--- a/src/ducks/modules/recentProtocols.js
+++ b/src/ducks/modules/recentProtocols.js
@@ -1,8 +1,11 @@
 import { existsSync } from 'fs';
 import { uniqBy } from 'lodash';
 import {
-  actionTypes as importActionTypes,
+  actionTypes as loadActions,
 } from './protocols/load';
+import {
+  actionTypes as exportActions,
+} from './protocols/export';
 
 const protocolExists = ({ filePath }) => existsSync(filePath);
 
@@ -16,12 +19,23 @@ const initialState = [];
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
-    case importActionTypes.LOAD_PROTOCOL_SUCCESS:
+    case loadActions.LOAD_PROTOCOL_SUCCESS: {
+      return state.map((protocol) => {
+        if (protocol.filePath !== action.meta.filePath) { return protocol; }
+
+        return {
+          ...protocol,
+          lastOpened: new Date().getTime(),
+        };
+      }).sort((a, b) => a.lastOpened < b.lastOpened);
+    }
+    case exportActions.EXPORT_PROTOCOL_SUCCESS: {
       return uniqBy([
-        { filePath: action.meta.filePath, lastOpened: new Date().getTime() },
+        { filePath: action.filePath, lastOpened: new Date().getTime() },
         ...state,
       ], 'filePath')
         .slice(0, 50);
+    }
     case CLEAR_DEAD_LINKS:
       return state.filter(protocolExists);
     default:


### PR DESCRIPTION
- When creating a protocol do not change recentProtocols
- When saving a protocol, add to recentProtocols
- When importing a protocol (i.e. opening from fs), add to recentProtocols
- When loading a protocol from the recentProtocol list, update last opened time, and move it to the front.

Resolves #411 