### PR TITLE
Feature/use shared development protocol

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+src/development-protocol
 src/ui
 src/network-canvas

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/network-canvas"]
 	path = src/network-canvas
 	url = https://github.com/codaco/Network-Canvas
+[submodule "src/development-protocol"]
+	path = src/development-protocol
+	url = git@github.com:codaco/development-protocol.git

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "jest": {
         "collectCoverageFrom": [
             "src/**/*.{js,jsx}",
+            "!src/development-protocol/**",
             "!src/ui/**",
             "!src/network-canvas/**"
         ],

--- a/src/utils/webShims/fs-extra.js
+++ b/src/utils/webShims/fs-extra.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
-const mockProtocol = require('./mockProtocol.json');
-const mockExternalJSONData = require('./mockExternalData.json');
+const mockProtocol = require('../../development-protocol/protocol.json');
+const mockExternalJSONData = require('../../development-protocol/assets/previousInterview.json');
 const mockExternalCSVData = "Name,Nickname,Age\nAnita,Annie,21\nBarry,Baz,28\nCarlito,Carl,23\nDee,Dee,40\nEugine,Eu,18\n";
 
 const copySync = () => {};


### PR DESCRIPTION
This is an attempt to resolve #377, by including the development protocol as a submodule.

It follows the existing pattern of importing the protocol file but has the following drawbacks:
- assets are still not usable
- external data (csv) is still loaded from text inline
- external data (json) is loaded from a hard-coded reference, so always references the same file.

### Suggested alternatives

#### Include development protocol in public, and write XMLHttpRequest shims to fetch data

The drawbacks with this are:
- will need to write code to emulate file loading over http
- will need to ensure this code is not included in production build
    
#### Retire web mode and rely on desktop app (which can load the development protocol from a file)

The drawbacks with this are:
- lose the benefits of fast iteration, when the protocol requires changes.

Resolves #377