### PR TITLE
Fix/interim feedback 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ There are two additional tasks to enable development within an electron app nati
 
 Electron supports [extensions to Chrome devtools](https://electronjs.org/docs/tutorial/devtools-extension) such as Redux DevTools.
 
-In the development environment, these will be loaded if you provide one or more paths to your extensions (semicolon-separated) in the `NC_DEVTOOLS_EXENSION_PATH` environment variable. The electron docs describe how to find the filepath for an extension once installed.
+In the development environment, these will be loaded if you provide one or more paths to your extensions (semicolon-separated) in the `NC_DEVTOOLS_EXTENSION_PATH` environment variable. The electron docs describe how to find the filepath for an extension once installed.
 
 Example: enabling Redux Devtools on macOS:
 ```bash
-NC_DEVTOOLS_EXENSION_PATH=~/Library/Application\ Support/Google/Chrome/Default/Extensions/lmhkpmbekcpmknklioeibfkpmmfibljd/2.15.2_0 npm run electron:dev
+NC_DEVTOOLS_EXTENSION_PATH=~/Library/Application\ Support/Google/Chrome/Default/Extensions/lmhkpmbekcpmknklioeibfkpmmfibljd/2.15.2_0 npm run electron:dev
 ```
 
 #### Environment options

--- a/public/components/appManager.js
+++ b/public/components/appManager.js
@@ -33,7 +33,7 @@ const appManager = {
     });
   },
   loadDevTools: () => {
-    const extensions = process.env.NC_DEVTOOLS_EXENSION_PATH;
+    const extensions = process.env.NC_DEVTOOLS_EXTENSION_PATH;
     if (process.env.NODE_ENV !== 'development' || !extensions) { return; }
     try {
       log.info(extensions);
@@ -44,8 +44,8 @@ const appManager = {
     } catch (err) {
       /* eslint-disable no-console */
       log.warn(err);
-      log.warn('A Chrome dev tools extension failed to load. If the extension has upgraded, update your NC_DEVTOOLS_EXENSION_PATH:');
-      log.warn(process.env.NC_DEVTOOLS_EXENSION_PATH);
+      log.warn('A Chrome dev tools extension failed to load. If the extension has upgraded, update your NC_DEVTOOLS_EXTENSION_PATH:');
+      log.warn(process.env.NC_DEVTOOLS_EXTENSION_PATH);
       /* eslint-enable */
     }
   },

--- a/public/components/assetProtocol.js
+++ b/public/components/assetProtocol.js
@@ -15,7 +15,8 @@ const isValidPath = filePath =>
 
 const registerProtocol = () =>
   protocol.registerFileProtocol(protocolName, (request, callback) => {
-    const filePath = path.normalize(request.url.substr(protocolName.length + 2));
+    const decodedURI = decodeURIComponent(request.url.substr(protocolName.length + 2));
+    const filePath = path.normalize(decodedURI);
 
     if (!isValidPath(filePath)) {
       throw new Error('path outside of valid directories');

--- a/src/components/Assets/withAssetUrl.js
+++ b/src/components/Assets/withAssetUrl.js
@@ -13,8 +13,9 @@ const mapStateToProps = (state, { id }) => {
   const assetManifest = getAssetManifest(state);
   const workingPath = activeProtocolMeta && activeProtocolMeta.workingPath;
   const source = get(assetManifest, [id, 'source'], '');
+  const encodedURI = encodeURIComponent(path.join(workingPath, 'assets', path.basename(source)));
   const url = source ?
-    `asset:/${path.join(workingPath, 'assets', path.basename(source))}` :
+    `asset:/${encodedURI}` :
     '';
 
   return {

--- a/src/components/Form/AutoFileDrop.js
+++ b/src/components/Form/AutoFileDrop.js
@@ -1,29 +1,45 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { findKey } from 'lodash';
 import { compose, withProps, withHandlers } from 'recompose';
 import Dropzone from './Dropzone';
 import { actionCreators as assetActions } from '../../ducks/modules/protocol/assetManifest';
 
 const ACCEPTS = {
-  network: ['text/csv', 'application/json'],
+  network: ['text/csv', 'application/json', 'text/*,', 'text/*', '.csv'], // text/*, is a workaround for windows not correctly setting mime type for CSV.
   image: ['image/*'],
   audio: ['audio/*'],
   video: ['video/*'],
 };
 
-const TYPES = [
-  [/text\/csv/, 'network'],
-  [/application\/json/, 'network'],
-  [/image\/.*/, 'image'],
-  [/audio\/.*/, 'audio'],
-  [/video\/.*/, 'video'],
-];
-
 const getTypeFromMime = (mime) => {
-  const match = TYPES.find(([matcher]) => matcher.test(mime));
+  const MIME_TYPES = [
+    [/text\/csv/, 'network'],
+    [/application\/json/, 'network'],
+    [/text\/*,/, 'network'],
+    [/image\/.*/, 'image'],
+    [/audio\/.*/, 'audio'],
+    [/video\/.*/, 'video'],
+  ];
+
+  const match = MIME_TYPES.find(([matcher]) => matcher.test(mime));
   if (!match) { return null; }
   return match[1];
 };
+
+const getTypeFromExtension = (name) => {
+  const EXTENSION_TYPES = {
+    network: ['csv', 'json'], // .csv
+    image: ['jpg', 'jpeg', 'gif', 'png'],
+    audio: ['mp3', 'aiff'],
+    video: ['mov', 'mp4'],
+  };
+
+  const extension = name.split('.').pop();
+
+  return findKey(EXTENSION_TYPES, type => type.includes(extension));
+};
+
 
 const mapDispatchToProps = dispatch => ({
   importAsset: bindActionCreators(assetActions.importAsset, dispatch),
@@ -42,7 +58,7 @@ const autoFileDrop = compose(
     onDrop: ({ importAsset, onDrop }) =>
       (acceptedFiles) => {
         acceptedFiles.forEach((file) => {
-          const type = getTypeFromMime(file.type);
+          const type = getTypeFromMime(file.type) || getTypeFromExtension(file.name);
 
           importAsset(file, type)
             .then(({ id }) => {

--- a/src/components/Form/Fields/DataSource.js
+++ b/src/components/Form/Fields/DataSource.js
@@ -50,10 +50,10 @@ class DataSource extends Component {
         { canUseExisting &&
           <div className="form-field-data-source__options">
             <div className="form-fields-data-source__option">
-              <Radio input={existingInput} label="Use network from interview" />
+              <Radio input={existingInput} label="Use the network from the in-progress interview" />
             </div>
             <div className="form-fields-data-source__option">
-              <Radio input={networkAssetInput} label="Use network asset" />
+              <Radio input={networkAssetInput} label="Use a network data file" />
               <div
                 className={cx(
                   'form-fields-data-source__option-file',

--- a/src/components/Guided/Guided.js
+++ b/src/components/Guided/Guided.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Guidance from './Guidance';
+// import Guidance from './Guidance';
 import { getGuidance } from '../../selectors/guidance';
 import { getContent } from '../../selectors/locales';
 import { actionCreators as settingsActions } from '../../ducks/modules/settings';
@@ -49,7 +49,7 @@ class Guided extends Component {
     const classNames = cx(
       this.props.className,
       'guided',
-      { 'guided--show-guidance': this.props.active },
+      // { 'guided--show-guidance': this.props.active },
     );
 
     return (
@@ -58,11 +58,11 @@ class Guided extends Component {
           { this.props.children }
         </div>
 
-        <Guidance
+        {/* <Guidance
           show={this.props.active}
           handleClickToggle={this.toggleGuidance}
           guidance={this.guidance}
-        />
+        /> */}
       </div>
     );
   }

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -17,7 +17,7 @@ const isNumberLike = value =>
 
 const minTwoOptions = value => (
   !value || value.length < 2 ?
-    'Requires a minimum of two options (a single option can be modelled by a checkbox field)' :
+    'Requires a minimum of two options. If you need fewer options, consider using a boolean variable.' :
     undefined
 );
 

--- a/src/components/Rules/Rules.js
+++ b/src/components/Rules/Rules.js
@@ -39,8 +39,8 @@ const Rules = ({
       <DetachedField
         component={RadioGroup}
         options={[
-          { label: 'All', value: 'AND' },
-          { label: 'Any', value: 'OR' },
+          { label: 'All of the following rules', value: 'AND' },
+          { label: 'Any of the following rules', value: 'OR' },
         ]}
         value={join}
         onChange={handleChangeJoin}

--- a/src/components/Screens/AssetsScreen.js
+++ b/src/components/Screens/AssetsScreen.js
@@ -34,7 +34,9 @@ const AssetBrowserScreen = ({
             <div className="editor__content">
               <h1 className="editor__heading">Assets</h1>
               <p>
-                Introduction to assets.
+                Welcome to the asset management screen. Here, you can load in images,
+                video, audio, or even externalnetwork data which can be used elsewhere
+                within your protocol.
               </p>
               <Guidance contentId="guidance.screen.assets">
                 <AssetBrowser />

--- a/src/components/StageEditor/Interfaces/Sociogram.js
+++ b/src/components/StageEditor/Interfaces/Sociogram.js
@@ -8,8 +8,8 @@ import {
 const Sociogram = {
   sections: [
     Name,
-    Background,
     NodeType,
+    Background,
     SociogramPrompts,
   ],
 };

--- a/src/components/TypeEditor/TypeEditor.js
+++ b/src/components/TypeEditor/TypeEditor.js
@@ -30,9 +30,10 @@ const TypeEditor = ({
       { !type && <h1 className="editor__heading">Create {entity}</h1> }
 
       <Guidance contentId="guidance.registry.type.label" className="editor__section">
-        <h3 id={getFieldId('name')}>Name</h3>
+        <h3 id={getFieldId('name')}>Node Type</h3>
         <p>
-          The node name is how you will refer to this node type in the rest of Architect.
+          What type of node is this? Common examples might be &quot;Person&quot;,
+          &quot;Place&quot;, or &quot;Agency&quot;.
         </p>
         <ValidatedField
           component={Fields.Text}

--- a/src/components/sections/Background.js
+++ b/src/components/sections/Background.js
@@ -22,6 +22,7 @@ class Background extends React.Component {
   }
 
   handleChooseBackgroundType = (option) => {
+    console.log(option);
     this.setState({ backgroundType: option });
   }
 

--- a/src/components/sections/Background.js
+++ b/src/components/sections/Background.js
@@ -3,6 +3,7 @@ import {
   Field,
 } from 'redux-form';
 import * as Fields from '../../ui/components/Fields';
+import ValidatedField from '../Form/ValidatedField';
 import * as ArchitectFields from '../Form/Fields';
 import Section from './Section';
 import Row from './Row';
@@ -53,7 +54,7 @@ class Background extends React.Component {
         { (backgroundType === CONCENTRIC_CIRCLES) &&
           <React.Fragment>
             <Row>
-              <Field
+              <ValidatedField
                 name="background.concentricCircles"
                 component={Fields.Number}
                 label="Number of concentric circles to use:"

--- a/src/components/sections/Background/Background.js
+++ b/src/components/sections/Background/Background.js
@@ -1,33 +1,28 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import {
   Field,
 } from 'redux-form';
-import * as Fields from '../../ui/components/Fields';
-import ValidatedField from '../Form/ValidatedField';
-import * as ArchitectFields from '../Form/Fields';
-import Section from './Section';
-import Row from './Row';
+import PropTypes from 'prop-types';
+import { compose } from 'recompose';
+import * as Fields from '../../../ui/components/Fields';
+import DetachedField from '../../DetachedField';
+import ValidatedField from '../../Form/ValidatedField';
+import * as ArchitectFields from '../../Form/Fields';
+import Section from '../Section';
+import Row from '../Row';
+import withBackgroundChangeHandler from './withBackgroundChangeHandler';
 
-// Background options
-const BACKGROUND_IMAGE = 'BACKGROUND/BACKGROUND_IMAGE';
-const CONCENTRIC_CIRCLES = 'BACKGROUND/CONCENTRIC_CIRCLES';
-
-class Background extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      backgroundType: CONCENTRIC_CIRCLES,
-    };
-  }
-
-  handleChooseBackgroundType = (option) => {
-    console.log(option);
-    this.setState({ backgroundType: option });
-  }
+class Background extends PureComponent {
+  static propTypes = {
+    handleChooseBackgroundType: PropTypes.func.isRequired,
+    useImage: PropTypes.bool.isRequired,
+  };
 
   render() {
-    const { backgroundType } = this.state;
+    const {
+      handleChooseBackgroundType,
+      useImage,
+    } = this.props;
 
     return (
       <Section contentId="guidance.editor.background">
@@ -40,19 +35,18 @@ class Background extends React.Component {
           </p>
         </Row>
         <Row>
-          <ArchitectFields.Mode
-            label="Choose a background type"
+          <DetachedField
+            component={ArchitectFields.Mode}
+            value={useImage}
             options={[
-              { value: CONCENTRIC_CIRCLES, label: 'Circles' },
-              { value: BACKGROUND_IMAGE, label: 'Image' },
+              { value: false, label: 'Circles' },
+              { value: true, label: 'Image' },
             ]}
-            input={{
-              value: backgroundType,
-              onChange: this.handleChooseBackgroundType,
-            }}
+            onChange={handleChooseBackgroundType}
+            label="Choose a background type"
           />
         </Row>
-        { (backgroundType === CONCENTRIC_CIRCLES) &&
+        { (!useImage) &&
           <React.Fragment>
             <Row>
               <ValidatedField
@@ -74,7 +68,7 @@ class Background extends React.Component {
             </Row>
           </React.Fragment>
         }
-        { (backgroundType === BACKGROUND_IMAGE) &&
+        { (useImage) &&
           <Row>
             <div style={{ position: 'relative', minHeight: '100px' }}>
               <Field
@@ -90,4 +84,8 @@ class Background extends React.Component {
   }
 }
 
-export default Background;
+export { Background };
+
+export default compose(
+  withBackgroundChangeHandler,
+)(Background);

--- a/src/components/sections/Background/index.js
+++ b/src/components/sections/Background/index.js
@@ -1,0 +1,1 @@
+export { default } from './Background';

--- a/src/components/sections/Background/withBackgroundChangeHandler.js
+++ b/src/components/sections/Background/withBackgroundChangeHandler.js
@@ -1,0 +1,43 @@
+import { connect } from 'react-redux';
+import { formValueSelector, change } from 'redux-form';
+import { compose, withState, withHandlers } from 'recompose';
+
+const withBackgroundChangeHandlerState = connect(
+  (state, { form }) => ({
+    useImage: !!formValueSelector(form)(state, 'background.image'),
+  }),
+  { changeForm: change },
+);
+
+const withBackgroundChangeHandlerEnabled = withState(
+  'useImage',
+  'setUseImage',
+  ({ useImage }) => !!useImage,
+);
+
+const withBackgroundChangeHandlers = withHandlers({
+  handleChooseBackgroundType: ({
+    setUseImage,
+    useImage,
+    form,
+    changeForm,
+  }) =>
+    () => {
+      if (useImage) {
+        changeForm(form, 'background.image', null);
+      } else {
+        changeForm(form, 'background.concentricCircles', null);
+        changeForm(form, 'background.skewedTowardCenter', null);
+      }
+
+      setUseImage(!useImage);
+    },
+});
+
+const withBackgroundChangeHandler = compose(
+  withBackgroundChangeHandlerState,
+  withBackgroundChangeHandlerEnabled,
+  withBackgroundChangeHandlers,
+);
+
+export default withBackgroundChangeHandler;

--- a/src/components/sections/CategoricalBinPrompts/CategoricalBinPrompts.js
+++ b/src/components/sections/CategoricalBinPrompts/CategoricalBinPrompts.js
@@ -16,8 +16,10 @@ const CategoricalBinPrompts = props => (
   >
     <h2>Edit Prompts</h2>
     <p>
-      Add one or more &quot;prompts&quot; below.
+      Add one or more prompts below to frame the task for the user. You can reorder
+      the prompts using the draggable handles on the left hand side.
     </p>
+    <p><strong>Tip: Tap an existing prompt to edit it.</strong></p>
   </EditableList>
 );
 

--- a/src/components/sections/CategoricalBinPrompts/PromptFields.js
+++ b/src/components/sections/CategoricalBinPrompts/PromptFields.js
@@ -35,6 +35,11 @@ const PromptFields = ({
     <Section>
       <Row>
         <h3 id={getFieldId('text')}>Text for Prompt</h3>
+        <p>Enter the text that the participant will see below.</p>
+        <p><strong>
+          Tip: You can use markdown formatting in this prompt to create
+          bold or underlined text.
+        </strong></p>
         <ValidatedField
           name={'text'}
           component={TextArea}

--- a/src/components/sections/CategoricalBinPrompts/PromptFields.js
+++ b/src/components/sections/CategoricalBinPrompts/PromptFields.js
@@ -53,6 +53,11 @@ const PromptFields = ({
           onCreateOption={openNewVariableWindow}
           onDeleteOption={handleDeleteVariable}
           validation={{ required: true }}
+          formatCreateLabel={inputValue => (
+            <span>
+              Press enter to create a new categorical variable named &quot;{inputValue}&quot;.
+            </span>
+          )}
         />
       </Row>
       <Row>

--- a/src/components/sections/Name.js
+++ b/src/components/sections/Name.js
@@ -7,7 +7,7 @@ import Section from './Section';
 const Name = () => (
   <Section contentId="guidance.editor.name">
     <div id={getFieldId('label')} data-name="Stage name" />
-    <h2>Name</h2>
+    <h2>Stage Name</h2>
     <p>
       Enter a name for your stage here. This name will appear in the timeline view of your
       protocol in both Architect and Network Canvas.

--- a/src/components/sections/NameGeneratorAutoCompletePrompts/PromptFields.js
+++ b/src/components/sections/NameGeneratorAutoCompletePrompts/PromptFields.js
@@ -34,7 +34,12 @@ const PromptFields = ({
       />
     </Row>
     <Row>
-      <h3>Assign attributes</h3>
+      <h3>Assign additional variables <small>(optional)</small></h3>
+      <p>
+        You may optionally assign variable values to all nodes created on this prompt.
+        Select an existing variable (and set a value), or select &quot;create new variable&quot;
+        from the bottom of the list.
+      </p>
       <AssignAttributes
         name="additionalAttributes"
         id="additionalAttributes"

--- a/src/components/sections/NameGeneratorAutoCompletePrompts/PromptFields.js
+++ b/src/components/sections/NameGeneratorAutoCompletePrompts/PromptFields.js
@@ -25,6 +25,11 @@ const PromptFields = ({
   <Section>
     <Row>
       <h3 id={getFieldId('text')}>Text for Prompt</h3>
+      <p>Enter the text that the participant will see below.</p>
+      <p><strong>
+        Tip: You can use markdown formatting in this prompt to create
+        bold or underlined text.
+      </strong></p>
       <ValidatedField
         name="text"
         component={Fields.TextArea}
@@ -34,11 +39,18 @@ const PromptFields = ({
       />
     </Row>
     <Row>
-      <h3>Assign additional variables <small>(optional)</small></h3>
+      <h3>Assign Additional Variables? <small>(optional)</small></h3>
       <p>
-        You may optionally assign variable values to all nodes created on this prompt.
-        Select an existing variable (and set a value), or select &quot;create new variable&quot;
-        from the bottom of the list.
+        You might also wish to assign additional variables to any nodes that are created by a
+        participant on this prompt. You can use this feature to keep track of meta-data,
+        such as where a node was elicited, or to reflect a name interpreter element of
+        your prompt (for example by adding a variable called &quot;close_tie&quot; variable to a
+        prompt that asks about closeness).
+      </p>
+      <p>
+        <strong>Tip: Select an existing variable, or select &quot;create new variable&quot;
+        from the bottom of the list, and then assign a value. You can set different values
+        for this variable for nodes created on different prompts.</strong>
       </p>
       <AssignAttributes
         name="additionalAttributes"

--- a/src/components/sections/NameGeneratorListPrompts/PromptFields.js
+++ b/src/components/sections/NameGeneratorListPrompts/PromptFields.js
@@ -39,7 +39,12 @@ const PromptFields = ({
         />
       </Row>
       <Row>
-        <h3>Assign attributes</h3>
+        <h3>Assign additional variables <small>(optional)</small></h3>
+        <p>
+            You may optionally assign variable values to all nodes created on this prompt.
+            Select an existing variable (and set a value), or select &quot;create new variable&quot;
+            from the bottom of the list.
+        </p>
         <AssignAttributes
           name="additionalAttributes"
           id="additionalAttributes"

--- a/src/components/sections/NameGeneratorListPrompts/PromptFields.js
+++ b/src/components/sections/NameGeneratorListPrompts/PromptFields.js
@@ -30,6 +30,11 @@ const PromptFields = ({
     <Section>
       <Row>
         <h3 id={getFieldId('text')}>Text for Prompt</h3>
+        <p>Enter the text that the participant will see below.</p>
+        <p><strong>
+          Tip: You can use markdown formatting in this prompt to create
+          bold or underlined text.
+        </strong></p>
         <ValidatedField
           name="text"
           component={TextArea}
@@ -39,11 +44,18 @@ const PromptFields = ({
         />
       </Row>
       <Row>
-        <h3>Assign additional variables <small>(optional)</small></h3>
+        <h3>Assign Additional Variables? <small>(optional)</small></h3>
         <p>
-            You may optionally assign variable values to all nodes created on this prompt.
-            Select an existing variable (and set a value), or select &quot;create new variable&quot;
-            from the bottom of the list.
+          You might also wish to assign additional variables to any nodes that are created by a
+          participant on this prompt. You can use this feature to keep track of meta-data,
+          such as where a node was elicited, or to reflect a name interpreter element of
+          your prompt (for example by adding a variable called &quot;close_tie&quot; variable to a
+          prompt that asks about closeness).
+        </p>
+        <p>
+          <strong>Tip: Select an existing variable, or select &quot;create new variable&quot;
+          from the bottom of the list, and then assign a value. You can set different values
+          for this variable for nodes created on different prompts.</strong>
         </p>
         <AssignAttributes
           name="additionalAttributes"

--- a/src/components/sections/NameGeneratorPrompts/PromptFields.js
+++ b/src/components/sections/NameGeneratorPrompts/PromptFields.js
@@ -29,7 +29,12 @@ class PromptFields extends PureComponent {
           />
         </Row>
         <Row>
-          <h3>Assign attributes</h3>
+          <h3>Assign additional variables <small>(optional)</small></h3>
+          <p>
+            You may optionally assign variable values to all nodes created on this prompt.
+            Select an existing variable (and set a value), or select &quot;create new variable&quot;
+            from the bottom of the list.
+          </p>
           <AssignAttributes
             form={form}
             name="additionalAttributes"

--- a/src/components/sections/NameGeneratorPrompts/PromptFields.js
+++ b/src/components/sections/NameGeneratorPrompts/PromptFields.js
@@ -19,6 +19,11 @@ class PromptFields extends PureComponent {
       <Section>
         <Row>
           <h3 id={getFieldId('text')}>Text for Prompt</h3>
+          <p>Enter the text that the participant will see below.</p>
+          <p><strong>
+            Tip: You can use markdown formatting in this prompt to create
+            bold or underlined text.
+          </strong></p>
           <ValidatedField
             name="text"
             component={TextArea}
@@ -29,11 +34,18 @@ class PromptFields extends PureComponent {
           />
         </Row>
         <Row>
-          <h3>Assign additional variables <small>(optional)</small></h3>
+          <h3>Assign Additional Variables? <small>(optional)</small></h3>
           <p>
-            You may optionally assign variable values to all nodes created on this prompt.
-            Select an existing variable (and set a value), or select &quot;create new variable&quot;
-            from the bottom of the list.
+            You might also wish to assign additional variables to any nodes that are created by a
+            participant on this prompt. You can use this feature to keep track of meta-data,
+            such as where a node was elicited, or to reflect a name interpreter element of
+            your prompt (for example by adding a variable called &quot;close_tie&quot; variable to a
+            prompt that asks about closeness).
+          </p>
+          <p>
+            <strong>Tip: Select an existing variable, or select &quot;create new variable&quot;
+            from the bottom of the list, and then assign a value. You can set different values
+            for this variable for nodes created on different prompts.</strong>
           </p>
           <AssignAttributes
             form={form}

--- a/src/components/sections/NarrativePresets/PresetFields.js
+++ b/src/components/sections/NarrativePresets/PresetFields.js
@@ -51,6 +51,9 @@ const PresetFields = ({
         options={layoutVariblesForSubject}
         onCreateOption={handleCreateLayoutVariable}
         onDeleteOption={handleDeleteVariable}
+        formatCreateLabel={inputValue => (
+          <span>Press enter to create a new layout variable named &quot;{inputValue}&quot;.</span>
+        )}
       />
     </Row>
     <Row>
@@ -61,6 +64,9 @@ const PresetFields = ({
         options={groupVariablesForSubject}
         onCreateOption={name => openNewVariableWindow(name)}
         onDeleteOption={handleDeleteVariable}
+        formatCreateLabel={inputValue => (
+          <span>Press enter to create a new boolean variable named &quot;{inputValue}&quot;.</span>
+        )}
       />
     </Row>
     <Row>

--- a/src/components/sections/NodePanels/NodePanel.js
+++ b/src/components/sections/NodePanels/NodePanel.js
@@ -15,10 +15,11 @@ const NodePanel = ({ fieldId, ...rest }) => (
     <Row>
       <h3>Panel title</h3>
       <p>The panel title will be shown above the list of nodes within the panel.</p>
-      <Field
+      <ValidatedField
         name={`${fieldId}.title`}
         component={Fields.Text}
         placeholder="Panel title"
+        validation={{ required: true }}
       />
     </Row>
     <Row>

--- a/src/components/sections/NodePanels/NodePanel.js
+++ b/src/components/sections/NodePanels/NodePanel.js
@@ -14,6 +14,7 @@ const NodePanel = ({ fieldId, ...rest }) => (
   <Item {...rest}>
     <Row>
       <h3>Panel title</h3>
+      <p>The panel title will be shown above the list of nodes within the panel.</p>
       <Field
         name={`${fieldId}.title`}
         component={Fields.Text}
@@ -25,6 +26,11 @@ const NodePanel = ({ fieldId, ...rest }) => (
         id={getFieldId(`${fieldId}.dataSource`)}
         data-name="Panel data source"
       >Data source</h3>
+      <p>
+        Choose where the data for this panel should come from (either the in-progress interview
+        session [&quot;People you have already named&quot;], or an external network data file
+        that you have added).
+      </p>
       <ValidatedField
         component={DataSource}
         name={`${fieldId}.dataSource`}
@@ -33,7 +39,11 @@ const NodePanel = ({ fieldId, ...rest }) => (
       />
     </Row>
     <Row>
-      <h3>Filter</h3>
+      <h3>Filter <small>(optional)</small></h3>
+      <p>
+        You can (optionally) filter the data to be shown in this panel, by one or more rules
+        using the options below.
+      </p>
       <Field
         name={`${fieldId}.filter`}
         component={FilterField}

--- a/src/components/sections/NodeType/NodeType.js
+++ b/src/components/sections/NodeType/NodeType.js
@@ -6,9 +6,7 @@ import cx from 'classnames';
 import Button from '../../../ui/components/Button';
 import { getFieldId } from '../../../utils/issues';
 import NodeSelect from '../../Form/Fields/NodeSelect';
-import Select from '../../Form/Fields/Select';
 import ValidatedField from '../../Form/ValidatedField';
-import DetachedField from '../../DetachedField';
 import withDisableAndReset from './withDisableAndReset';
 import withCreateNewType from './withCreateNewType';
 import withNodeTypeOptions from './withNodeTypeOptions';
@@ -24,9 +22,6 @@ class NodeType extends Component {
     handleResetStage: PropTypes.func.isRequired,
     handleOpenCreateNewType: PropTypes.func.isRequired,
     handleTypeScreenMessage: PropTypes.func.isRequired,
-    displayVariable: PropTypes.string,
-    handleChangeDisplayVariable: PropTypes.func.isRequired,
-    displayVariableOptions: PropTypes.array.isRequired,
   };
 
   static defaultProps = {
@@ -46,9 +41,6 @@ class NodeType extends Component {
       disabled,
       handleResetStage,
       handleOpenCreateNewType,
-      displayVariable,
-      handleChangeDisplayVariable,
-      displayVariableOptions,
     } = this.props;
 
     const nodeTypeClasses = cx('stage-editor-section', 'stage-editor-section-node-type', { 'stage-editor-section-node-type--disabled': disabled });

--- a/src/components/sections/NodeType/NodeType.js
+++ b/src/components/sections/NodeType/NodeType.js
@@ -101,7 +101,7 @@ class NodeType extends Component {
             </p>
             <p>
               <strong>
-                This open is global: changing it here will change it for every interface that uses
+                This option is global: changing it here will change it for every interface that uses
                 this node type.
               </strong>
             </p>

--- a/src/components/sections/NodeType/NodeType.js
+++ b/src/components/sections/NodeType/NodeType.js
@@ -50,7 +50,7 @@ class NodeType extends Component {
         <Row>
           <div id={getFieldId('subject')} data-name="Node type" />
           <h2>Node Type</h2>
-          <p>Which node type is used on this interface?</p>
+          <p>Which node type is used on this stage?</p>
           <div
             className="stage-editor-section-node-type__edit"
             onClick={handleResetStage}

--- a/src/components/sections/NodeType/NodeType.js
+++ b/src/components/sections/NodeType/NodeType.js
@@ -90,31 +90,6 @@ class NodeType extends Component {
             </div>
           </div>
         </Row>
-
-        { disabled &&
-          <Row>
-            <h4>Display Variable <small>(optional)</small></h4>
-            <p>
-                Optionally, you may specify an existing variable to use as a label when
-                displaying this node type. If you do not specify a variable, Network Canvas
-                will select an appropriate one for you, using <a href="https://documentation.networkcanvas.com">these rules</a>.
-            </p>
-            <p>
-              <strong>
-                This option is global: changing it here will change it for every interface that uses
-                this node type.
-              </strong>
-            </p>
-            <DetachedField
-              label=""
-              component={Select}
-              placeholder="&mdash; Select from your existing variables &mdash;"
-              value={displayVariable}
-              onChange={handleChangeDisplayVariable}
-              options={displayVariableOptions}
-            />
-          </Row>
-        }
       </Section>
     );
   }

--- a/src/components/sections/NodeType/NodeType.js
+++ b/src/components/sections/NodeType/NodeType.js
@@ -93,11 +93,11 @@ class NodeType extends Component {
 
         { disabled &&
           <Row>
-            <h4>Display Variable</h4>
+            <h4>Display Variable <small>(optional)</small></h4>
             <p>
-                Optionally, you may specify a variable to use as a label when displaying this node.
-                If you do not specify a variable, Network Canvas will select an appropriate
-                one for you, using <a href="https://documentation.networkcanvas.com">these rules</a>.
+                Optionally, you may specify an existing variable to use as a label when
+                displaying this node type. If you do not specify a variable, Network Canvas
+                will select an appropriate one for you, using <a href="https://documentation.networkcanvas.com">these rules</a>.
             </p>
             <p>
               <strong>
@@ -108,7 +108,7 @@ class NodeType extends Component {
             <DetachedField
               label=""
               component={Select}
-              placeholder="&mdash; Select or create a display variable &mdash;"
+              placeholder="&mdash; Select from your existing variables &mdash;"
               value={displayVariable}
               onChange={handleChangeDisplayVariable}
               options={displayVariableOptions}

--- a/src/components/sections/OrdinalBinPrompts/OrdinalBinPrompts.js
+++ b/src/components/sections/OrdinalBinPrompts/OrdinalBinPrompts.js
@@ -19,8 +19,10 @@ const OrdinalBinPrompts = props => (
   >
     <h2>Prompts</h2>
     <p>
-      Add one or more &quot;prompts&quot; below.
+      Add one or more prompts below to frame the task for the user.
+      You can reorder the prompts using the draggable handles on the left hand side.
     </p>
+    <p><strong>Tip: Tap an existing prompt to edit it.</strong></p>
   </EditableList>
 );
 

--- a/src/components/sections/OrdinalBinPrompts/PromptFields.js
+++ b/src/components/sections/OrdinalBinPrompts/PromptFields.js
@@ -54,6 +54,11 @@ const PromptFields = ({
           onCreateOption={openNewVariableWindow}
           onDeleteOption={handleDeleteVariable}
           validation={{ required: true }}
+          formatCreateLabel={inputValue => (
+            <span>
+              Press enter to create a new ordinal variable named &quot;{inputValue}&quot;.
+            </span>
+          )}
         />
       </Row>
       <Row>

--- a/src/components/sections/OrdinalBinPrompts/PromptFields.js
+++ b/src/components/sections/OrdinalBinPrompts/PromptFields.js
@@ -36,6 +36,11 @@ const PromptFields = ({
     <Section>
       <Row>
         <h3 id={getFieldId('text')}>Text for Prompt</h3>
+        <p>Enter the text that the participant will see below.</p>
+        <p><strong>
+          Tip: You can use markdown formatting in this prompt to create
+          bold or underlined text.
+        </strong></p>
         <ValidatedField
           name="text"
           component={TextArea}
@@ -46,6 +51,10 @@ const PromptFields = ({
       </Row>
       <Row>
         <h3 id={getFieldId('variable')}>Ordinal variable</h3>
+        <p>
+          Select an existing ordinal variable from the list below, or create a new onDeleteOption
+          by typing a name into the box and pressing enter.
+        </p>
         <ValidatedField
           name="variable"
           component={CreatableSelect}
@@ -63,7 +72,13 @@ const PromptFields = ({
       </Row>
       <Row>
         <div id={getFieldId('color')} data-name="Gradient color" />
-        <p>What color would you like to use for the gradient?</p>
+        <p>
+          Network Canvas will render each option in your ordinal variable using a
+          color gradient. Which color would you like to use for this scale?
+        </p>
+        <p><strong>Tip: Consider using a color consistently throughout your interview protocol
+          to represent each theme, to help reenforce the idea to your participants.
+        </strong></p>
         <ValidatedField
           component={ColorPicker}
           name="color"
@@ -73,21 +88,16 @@ const PromptFields = ({
         />
       </Row>
       <Row>
-        <h3>Bin Sort Order</h3>
-        <p>How should nodes be sorted when inside the bins?</p>
-        <MultiSelect
-          name="binSortOrder"
-          properties={[
-            { fieldName: 'property' },
-            { fieldName: 'direction' },
-          ]}
-          maxItems={sortMaxItems}
-          options={getSortOrderOptionGetter(variableOptions)}
-        />
-      </Row>
-      <Row>
-        <h3>Bucket Sort Order</h3>
-        <p>How would you like to sort the unplaced nodes?</p>
+        <h3>Bucket Sort Order <small>(optional)</small></h3>
+        <p>
+          Nodes begin in the bucket before they are placed, and so this option impacts the
+          order that nodes are categorised. You may optionally configure a list of rules
+          to determine how nodes are sorted in the bucket when the task starts. Network Canvas
+          will default to using the order in which nodes were named.
+        </p>
+        <p><strong>
+          Tip: Use the asterisk property to sort by the order that nodes were created.
+        </strong></p>
         <MultiSelect
           name="bucketSortOrder"
           properties={[
@@ -98,6 +108,23 @@ const PromptFields = ({
           options={getSortOrderOptionGetter(variableOptions)}
         />
       </Row>
+      <Row>
+        <h3>Bin Sort Order <small>(optional)</small></h3>
+        <p>
+          You may also configure one or more sort rules that determine the order that nodes
+          are listed after they have been placed into a bin.
+        </p>
+        <MultiSelect
+          name="binSortOrder"
+          properties={[
+            { fieldName: 'property' },
+            { fieldName: 'direction' },
+          ]}
+          maxItems={sortMaxItems}
+          options={getSortOrderOptionGetter(variableOptions)}
+        />
+      </Row>
+
 
       <NewVariableWindow
         initialValues={{

--- a/src/components/sections/QuickAdd/QuickAdd.js
+++ b/src/components/sections/QuickAdd/QuickAdd.js
@@ -19,16 +19,28 @@ const QuickAdd = ({
 }) => (
   <Section disabled={disabled} group contentId="guidance.editor.quickAdd">
     <h3 id="issue-form">Quick Add Variable</h3>
-    <p>Choose which variable to use to store the value of the quick add form.</p>
+    <p>
+      Choose which variable to use to store the value of the quick add form. To create
+      a new variable, type a name into the box below.
+    </p>
+    <p>
+      <strong>
+        Tip: create or assign a variable called &quot;name&quot; and network
+        canvas will automatically use it as a label.
+      </strong>
+    </p>
     <div className="stage-editor-section-form">
       <ValidatedField
         name="quickAdd"
         component={CreatableSelect}
-        placeholder="Select component"
+        placeholder="Select an existing variable, or type to create a new one..."
         options={options}
         onCreateOption={value => handleCreateVariable(value, 'text')}
         onDeleteOption={handleDeleteVariable}
         validation={{ required: true }}
+        formatCreateLabel={inputValue => (
+          <span>Press enter to create a new variable named &quot;{inputValue}&quot;.</span>
+        )}
       />
     </div>
   </Section>

--- a/src/components/sections/SociogramPrompts/PromptFieldsEdges.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsEdges.js
@@ -54,6 +54,9 @@ const EdgeFields = ({
             placeholder="&mdash; Select an edge type, or type to create a new one &mdash;"
             label="Create edges of the following type"
             validation={{ required: true }}
+            formatCreateLabel={inputValue => (
+              <span>Press enter to create a edge type named &quot;{inputValue}&quot;.</span>
+            )}
           />
         </Row>
       }

--- a/src/components/sections/SociogramPrompts/PromptFieldsEdges.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsEdges.js
@@ -10,6 +10,7 @@ import Section from '../Section';
 import withEdgesOptions from './withEdgesOptions';
 import withEdgeHighlightChangeHandler from './withEdgeHighlightChangeHandler';
 import withCreateEdgeHandlers from '../../enhancers/withCreateEdgeHandler';
+import { ValidatedField } from '../../Form';
 
 const EdgeFields = ({
   edgesForSubject,
@@ -34,14 +35,6 @@ const EdgeFields = ({
         </p>
       </Row>
       <Row>
-        <Field
-          name="edges.display"
-          component={Fields.CheckboxGroup}
-          options={edgesForSubject}
-          label="Display edges of the following type(s):"
-        />
-      </Row>
-      <Row>
         <DetachedField
           component={Fields.Toggle}
           value={canCreateEdge}
@@ -53,16 +46,34 @@ const EdgeFields = ({
       </Row>
       { canCreateEdge &&
         <Row>
-          <Field
+          <ValidatedField
             name="edges.create"
             component={ArchitectFields.CreatableSelect}
             options={edgesForSubject}
             onCreateOption={handleCreateEdge}
-            placeholder="&mdash; Select or create a new edge type &mdash;"
+            placeholder="&mdash; Select an edge type, or type to create a new one &mdash;"
             label="Create edges of the following type"
+            validation={{ required: true }}
           />
         </Row>
       }
+      <Row>
+        { edgesForSubject.length > 0 ?
+          (
+            <Field
+              name="edges.display"
+              component={Fields.CheckboxGroup}
+              options={edgesForSubject}
+              label="Display edges of the following type(s):"
+            />
+          ) : (
+            <React.Fragment>
+              <h4>No edge types defined.</h4>
+              <p>Create some edge types elsewhere in your interview, and they will appear here.</p>
+            </React.Fragment>
+          )
+        }
+      </Row>
     </Section>
   );
 };

--- a/src/components/sections/SociogramPrompts/PromptFieldsHighlight.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsHighlight.js
@@ -47,6 +47,11 @@ const HighlightFields = ({
           onCreateOption={value => handleCreateVariable(value, 'boolean')}
           placeholder="&mdash; Select a variable to toggle, or type a name to create a new one &mdash;"
           options={highlightVariablesForSubject}
+          formatCreateLabel={inputValue => (
+            <span>
+              Press enter to create a new boolean variable named &quot;{inputValue}&quot;.
+            </span>
+          )}
         />
       </Row>
     </Section>

--- a/src/components/sections/SociogramPrompts/PromptFieldsHighlight.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsHighlight.js
@@ -45,7 +45,7 @@ const HighlightFields = ({
           component={ArchitectFields.CreatableSelect}
           label="Toggle variable of the following type"
           onCreateOption={value => handleCreateVariable(value, 'boolean')}
-          placeholder="&mdash; Select or create a new variable to toggle &mdash;"
+          placeholder="&mdash; Select a variable to toggle, or type a name to create a new one &mdash;"
           options={highlightVariablesForSubject}
         />
       </Row>

--- a/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
@@ -32,7 +32,7 @@ const PromptFields = ({
       <ValidatedField
         name="layout.layoutVariable"
         component={ArchitectFields.CreatableSelect}
-        placeholder="&mdash; Select or create a new layout variable &mdash;"
+        placeholder="&mdash; Select a new layout variable, or type to create a new one &mdash;"
         validation={{ required: true }}
         options={layoutVariablesForSubject}
         onCreateOption={value => handleCreateVariable(value, 'layout')}

--- a/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
@@ -23,14 +23,12 @@ const PromptFields = ({
       <div id={getFieldId('layout.layoutVariable')} data-name="Layout Variable" />
       <h3>Layout</h3>
       <p>
-        This section controls the position of nodes on this sociogram prompt. Decide
-        if you want the participant to be able to drag nodes to position them, and
-        select a layout variable to use for storing or retrieving position data.
+        This section controls the position of nodes on this sociogram prompt.
       </p>
     </Row>
     <Row>
       <h4>Layout variable</h4>
-      <p>Which layout do you want to use on this prompt?</p>
+      <p>Which variable should be used to store or retrieve the X/Y coordinates of nodes?</p>
       <ValidatedField
         name="layout.layoutVariable"
         component={ArchitectFields.CreatableSelect}

--- a/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
@@ -36,6 +36,9 @@ const PromptFields = ({
         validation={{ required: true }}
         options={layoutVariablesForSubject}
         onCreateOption={value => handleCreateVariable(value, 'layout')}
+        formatCreateLabel={inputValue => (
+          <span>Press enter to create a new layout variable named &quot;{inputValue}&quot;.</span>
+        )}
       />
     </Row>
     <Row>

--- a/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
@@ -29,6 +29,9 @@ const PromptFields = ({
     <Row>
       <h4>Layout variable</h4>
       <p>Which variable should be used to store or retrieve the X/Y coordinates of nodes?</p>
+      <p><strong>
+        Tip: Remember, you can create a new layout variable here by typing a name into the box.
+      </strong></p>
       <ValidatedField
         name="layout.layoutVariable"
         component={ArchitectFields.CreatableSelect}

--- a/src/ducks/middleware/logger.js
+++ b/src/ducks/middleware/logger.js
@@ -8,7 +8,7 @@ const logger = createLogger({
   collapsed: true,
   logger: console,
   predicate: (getState, action) => (
-    !/^@@redux-form/.test(String(action.type)) &&
+    // !/^@@redux-form/.test(String(action.type)) &&
     !/^GUIDANCE/.test(String(action.type))
   ),
 });

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -245,7 +245,7 @@ export default {
       </p>
       <p>
         Node types are fundamental to the way that Network Canvas works. A node&apos;s type
-        determines it&apos;s visual properties, as well as the variables available to assign on
+        determines its visual properties, as well as the variables available to assign on
         other interfaces.
       </p>
     </Fragment>
@@ -253,7 +253,7 @@ export default {
   'guidance.editor.quickAdd': (
     <Fragment>
       <h3>The Quick Add function</h3>
-      <p>Using the quick add function allowa your participants to create a node by simply
+      <p>Using the quick add function allows your participants to create a node by simply
         entering a display label for it and pressing the enter key. The quick add form does not
         obscure the node list, and will stay open and focused while the participant types,
         providing an ideal environment for quickly listing off names.
@@ -368,7 +368,7 @@ export default {
       </p>
       <p>
         Prompts should be carefully considered, and grounded in existing literature wherever
-        possible.  Think carefully about if you want to use one name generator with muiltiple
+        possible.  Think carefully about if you want to use one name generator with multiple
         prompts, or many name generators with a single prompt. Your choice depends on your specific
         research goals, and the needs of your research population.
       </p>
@@ -389,7 +389,7 @@ export default {
       </p>
       <p>
         Prompts should be carefully considered, and grounded in existing literature wherever
-        possible.  Think carefully about if you want to use one name generator with muiltiple
+        possible.  Think carefully about if you want to use one name generator with multiple
         prompts, or many name generators with a single prompt. Your choice depends on your specific
         research goals, and the needs of your research population.
       </p>
@@ -410,7 +410,7 @@ export default {
       </p>
       <p>
         Prompts should be carefully considered, and grounded in existing literature wherever
-        possible.  Think carefully about if you want to use one name generator with muiltiple
+        possible.  Think carefully about if you want to use one name generator with multiple
         prompts, or many name generators with a single prompt. Your choice depends on your specific
         research goals, and the needs of your research population.
       </p>

--- a/src/styles/components/form/fields/_node-select.scss
+++ b/src/styles/components/form/fields/_node-select.scss
@@ -2,6 +2,7 @@
   background: none;
   display: block;
   padding: 0;
+  margin-bottom: 1rem;
 
   .node-type {
     display: inline-block;


### PR DESCRIPTION
This PR contains fixes for issues identified in the first interim build:

- clarified the purpose of display label
- fixed a typo in the display label text
- added explanatory text to panel and filtering sections
- made panel title required
- reordered the sociogram edge section
- numerous protocol validation issues, some of which were fixed in NC and protocol-validation directly.
- using image asset from saved assets on sociogram interface and info interface caused "path outside of valid directories" error. fixed by using encodeURIComponent
- could not open CSV file for import on windows. bodged by looking up file extension to bypass missing MIME type,

Additional feedback that I added to this:

- Enhanced the create select component to display info about what is being created
- Temporarily removed the rendering of the guidance component - there is too much missing, and not enough time to add it back in. We will return to it during beta.
- Removed the concept of choosing a display label within Architect. The feature will still exist for manually coded protocols. This effectively makes node label default to the name property. Text has been added to this effect.
- Added a data cleaning function to the onSubmit form handler that removes null values and empty objects and arrays. This will help with protocol validation.

**Note: this is a duplicate of https://github.com/codaco/Architect/pull/477, which was reverted after a erroneous merge**