### PR TITLE
Unique names for variables

### DIFF
--- a/src/components/EditableList/EditableList.js
+++ b/src/components/EditableList/EditableList.js
@@ -52,6 +52,7 @@ class EditableList extends PureComponent {
       initialValues,
       editComponent: EditComponent,
       previewComponent: PreviewComponent,
+      editProps,
       ...rest
     } = this.props;
 
@@ -92,9 +93,11 @@ class EditableList extends PureComponent {
               onSubmitFail={handleSubmitFail}
               onCancel={handleResetEditField}
               form={formName}
+              {...editProps}
             >
               <EditComponent
                 {...rest}
+                {...editProps}
                 form={formName}
                 fieldId={editField}
                 onComplete={handleResetEditField}

--- a/src/components/EditableList/withEditHandlers.js
+++ b/src/components/EditableList/withEditHandlers.js
@@ -48,8 +48,8 @@ const handlers = withHandlers({
     onChange,
   }) =>
     (value) => {
-      upsert(editField, normalize(value));
-      if (onChange) { onChange(value); }
+      const newValue = onChange ? normalize(onChange(value)) : normalize(value);
+      upsert(editField, newValue);
       setImmediate(() => {
         setEditField();
       });

--- a/src/components/Form/Fields/CreatableSelect.js
+++ b/src/components/Form/Fields/CreatableSelect.js
@@ -124,7 +124,6 @@ class Select extends PureComponent {
           // a round about way, and still allow us to use the `touched` property.
           onBlur={this.handleBlur}
           blurInputOnSelect={false}
-          giveThisToOption={() => false}
           {...rest}
         >
           {children}

--- a/src/components/NewVariableWindow/NewVariableWindow.js
+++ b/src/components/NewVariableWindow/NewVariableWindow.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
 import { getFieldId } from '../../utils/issues';
 import * as Fields from '../../ui/components/Fields';
 import ValidatedField from '../Form/ValidatedField';
@@ -9,12 +10,14 @@ import Options from '../Options';
 import Section from '../sections/Section';
 import FormWindow from '../FormWindow';
 import withNewVariableHandler, { form } from './withNewVariableHandler';
+import { validateName } from '../../utils/validations';
 
 const NewVariableWindow = ({
   show,
   variableType,
   allowVariableTypes,
   handleCreateNewVariable,
+  existingVariableNames,
   onCancel,
   initialValues,
 }) => {
@@ -32,6 +35,7 @@ const NewVariableWindow = ({
       onSubmit={handleCreateNewVariable}
       onCancel={onCancel}
       initialValues={initialValues}
+      existingVariableNames={existingVariableNames}
     >
       <Section contentId="guidance.newVariable.name">
         <h3 id={getFieldId('name')}>Variable name</h3>
@@ -39,11 +43,11 @@ const NewVariableWindow = ({
           Enter a name for this variable. The variable name is how you will reference
           the variable elsewhere, including in exported data.
         </p>
-        <ValidatedField
+        <Field
           name="name"
           component={Fields.Text}
           placeholder="e.g. Nickname"
-          validation={{ required: true }}
+          validate={validateName}
         />
       </Section>
       <Section contentId="guidance.newVariable.type">
@@ -82,6 +86,7 @@ NewVariableWindow.propTypes = {
   handleCreateNewVariable: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   initialValues: PropTypes.object,
+  existingVariableNames: PropTypes.array.isRequired,
 };
 
 NewVariableWindow.defaultProps = {

--- a/src/components/NewVariableWindow/withNewVariableHandler.js
+++ b/src/components/NewVariableWindow/withNewVariableHandler.js
@@ -1,15 +1,21 @@
 import { connect } from 'react-redux';
 import { formValueSelector } from 'redux-form';
 import { compose, withHandlers } from 'recompose';
+import { values } from 'lodash';
+import { getVariablesForSubject } from '../../selectors/codebook';
 import { actionCreators as codebookActions } from '../../ducks/modules/protocol/codebook';
 
 export const form = 'create-new-variable';
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, { entity, type }) => {
   const variableType = formValueSelector(form)(state, 'type');
+  const existingVariables = getVariablesForSubject(state, { entity, type });
+  const existingVariableNames = values(existingVariables)
+    .map(({ name }) => name);
 
   return {
     variableType,
+    existingVariableNames,
   };
 };
 

--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { formValueSelector, change } from 'redux-form';
+import { formValueSelector, change, Field } from 'redux-form';
 import { withHandlers, compose } from 'recompose';
 import { getFieldId } from '../../../utils/issues';
 import { ValidatedField } from '../../Form';
@@ -11,6 +11,7 @@ import Options from '../../Options';
 import Validations from '../../Validations';
 import SelectOptionImage from '../../Form/Fields/SelectOptionImage';
 import inputOptions, { getTypeForComponent, isVariableTypeWithOptions } from '../../Form/inputOptions';
+import { validateName } from '../../../utils/validations';
 import Row from '../Row';
 import Section from '../Section';
 
@@ -36,7 +37,11 @@ const handlers = {
     },
 };
 
-const PromptFields = ({ form, variableType, handleChangeComponent }) => (
+const PromptFields = ({
+  form,
+  variableType,
+  handleChangeComponent,
+}) => (
   <Section>
     <Row contentId="guidance.section.form.field.name">
       <h3 id={getFieldId('name')}>Variable name</h3>
@@ -44,12 +49,11 @@ const PromptFields = ({ form, variableType, handleChangeComponent }) => (
         Enter a name for this variable. The variable name is how you will
         reference the variable elsewhere, including in exported data.
       </p>
-      <ValidatedField
+      <Field
         name="name"
         component={Fields.Text}
         placeholder="e.g. Name"
-        validation={{ required: true }}
-        // TODO: safename
+        validate={validateName}
       />
     </Row>
     <Row contentId="guidance.section.form.field.prompt">

--- a/src/components/sections/Form/Form.js
+++ b/src/components/sections/Form/Form.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'recompose';
-import uuid from 'uuid';
 import TextField from '../../../ui/components/Fields/Text';
 import ValidatedField from '../../Form/ValidatedField';
 import EditableList from '../../EditableList';
@@ -13,14 +12,13 @@ import withFieldChangeHandlers from './withFieldChangeHandlers';
 import withDisabledSubjectRequired from '../../enhancers/withDisabledSubjectRequired';
 import { itemSelector, normalizeField } from './helpers';
 
-const template = () => ({ variable: uuid() });
-
 const Form = ({
   handleChangeFields,
   form,
   disabled,
   type,
   entity,
+  existingVariableNames,
 }) => (
   <Section disabled={disabled} group contentId="guidance.section.form">
     <div id={getFieldId('form.title')} data-name="Form title" />
@@ -39,11 +37,15 @@ const Form = ({
 
     <EditableList
       editComponent={FieldFields}
+      editProps={{
+        type,
+        entity,
+        existingVariableNames,
+      }}
       previewComponent={FieldPreview}
       fieldName="form.fields"
       title="Edit Field"
       onChange={handleChangeFields}
-      template={template}
       normalize={normalizeField}
       itemSelector={itemSelector(entity, type)}
       form={form}
@@ -66,6 +68,7 @@ Form.propTypes = {
   disabled: PropTypes.bool,
   type: PropTypes.string,
   entity: PropTypes.string,
+  existingVariableNames: PropTypes.array.isRequired,
 };
 
 Form.defaultProps = {

--- a/src/components/sections/Form/withFieldChangeHandlers.js
+++ b/src/components/sections/Form/withFieldChangeHandlers.js
@@ -1,36 +1,49 @@
 import { connect } from 'react-redux';
 import { compose, withHandlers } from 'recompose';
+import { values } from 'lodash';
 import withSubject from '../../enhancers/withSubject';
 import { actionCreators as codebookActions } from '../../../ducks/modules/protocol/codebook';
 import { getTypeForComponent } from '../../Form/inputOptions';
 import { getCodebookProperties } from './helpers';
+import { getVariablesForSubject } from '../../../selectors/codebook';
+
+const mapFormProperties = (state, { entity, type }) => {
+  const existingVariables = getVariablesForSubject(state, { entity, type });
+  const existingVariableNames = values(existingVariables)
+    .map(({ name }) => name);
+
+  return {
+    existingVariableNames,
+  };
+};
 
 const fieldChangeHandlers = withHandlers({
-  handleChangeFields: ({ updateVariable, type, entity }) =>
+  handleChangeFields: ({ createVariable, updateVariable, type, entity }) =>
     ({ variable, component, ...rest }) => {
       const variableType = getTypeForComponent(component);
+      // prune properties that are not part of the codebook:
       const codebookProperties = getCodebookProperties(rest);
       const configuration = {
         type: variableType,
         ...codebookProperties,
       };
 
-      updateVariable(
-        entity,
-        type,
-        variable,
-        configuration,
-      );
+      if (variable) {
+        return updateVariable(entity, type, variable, configuration);
+      }
+
+      return createVariable(entity, type, configuration); // TODO: we need variable id
     },
 });
 
 const mapDispatchToProps = {
+  createVariable: codebookActions.createVariable,
   updateVariable: codebookActions.updateVariable,
 };
 
 const withFieldChangeHandlers = compose(
   withSubject,
-  connect(null, mapDispatchToProps),
+  connect(mapFormProperties, mapDispatchToProps),
   fieldChangeHandlers,
 );
 

--- a/src/components/sections/Form/withFieldChangeHandlers.js
+++ b/src/components/sections/Form/withFieldChangeHandlers.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { compose, withHandlers } from 'recompose';
-import { values } from 'lodash';
+import { values as getValues } from 'lodash';
 import withSubject from '../../enhancers/withSubject';
 import { actionCreators as codebookActions } from '../../../ducks/modules/protocol/codebook';
 import { getTypeForComponent } from '../../Form/inputOptions';
@@ -9,7 +9,7 @@ import { getVariablesForSubject } from '../../../selectors/codebook';
 
 const mapFormProperties = (state, { entity, type }) => {
   const existingVariables = getVariablesForSubject(state, { entity, type });
-  const existingVariableNames = values(existingVariables)
+  const existingVariableNames = getValues(existingVariables)
     .map(({ name }) => name);
 
   return {
@@ -19,7 +19,8 @@ const mapFormProperties = (state, { entity, type }) => {
 
 const fieldChangeHandlers = withHandlers({
   handleChangeFields: ({ createVariable, updateVariable, type, entity }) =>
-    ({ variable, component, ...rest }) => {
+    (values) => {
+      const { variable, component, ...rest } = values;
       const variableType = getTypeForComponent(component);
       // prune properties that are not part of the codebook:
       const codebookProperties = getCodebookProperties(rest);
@@ -29,10 +30,12 @@ const fieldChangeHandlers = withHandlers({
       };
 
       if (variable) {
-        return updateVariable(entity, type, variable, configuration);
+        updateVariable(entity, type, variable, configuration);
+        return values;
       }
 
-      return createVariable(entity, type, configuration); // TODO: we need variable id
+      const result = createVariable(entity, type, configuration);
+      return { ...values, variable: result.variable };
     },
 });
 

--- a/src/ducks/modules/__tests__/session.test.js
+++ b/src/ducks/modules/__tests__/session.test.js
@@ -72,11 +72,11 @@ describe('session reducer', () => {
     });
 
     it('tracks create variable as change', () => {
-      itTracksActionAsChange(codebookActions.createVariable());
+      itTracksActionAsChange(codebookTesting.createVariable());
     });
 
     it('tracks update variable as change', () => {
-      itTracksActionAsChange(codebookActions.updateVariable());
+      itTracksActionAsChange(codebookTesting.updateVariable());
     });
   });
 });

--- a/src/ducks/modules/protocol/__tests__/codebook.test.js
+++ b/src/ducks/modules/protocol/__tests__/codebook.test.js
@@ -107,7 +107,7 @@ describe('protocol.codebook', () => {
             node: { foo: { variables: { bar: { baz: 'buzz' } } } },
             edge: {},
           },
-          actionCreators.updateVariable('node', 'foo', 'bar', { fizz: 'pop' }),
+          testing.updateVariable('node', 'foo', 'bar', { fizz: 'pop' }),
         );
 
         expect(result).toMatchSnapshot();
@@ -118,7 +118,7 @@ describe('protocol.codebook', () => {
           {
             ego: { variables: { bar: { baz: 'buzz' } } },
           },
-          actionCreators.updateVariable('ego', undefined, 'bar', { fizz: 'pop' }),
+          testing.updateVariable('ego', undefined, 'bar', { fizz: 'pop' }),
         );
 
         expect(result).toMatchSnapshot();
@@ -218,6 +218,49 @@ describe('protocol.codebook', () => {
           },
           configuration: { fizz: 'buzz' },
         });
+      });
+
+      it('throws an error if a variable with the same name already exists', () => {
+        const createAction = actionCreators.createVariable('node', 'bar', { name: 'ALPHA' });
+        const store = mockStore(testState);
+
+        expect(() => {
+          store.dispatch(createAction);
+        }).toThrow(new Error('Variable with name "ALPHA" already exists'));
+      });
+    });
+
+    describe('updateVariable()', () => {
+      it('dispatches the UPDATE_VARIABLE action', () => {
+        const store = mockStore(testState);
+
+        store.dispatch(actionCreators.updateVariable(
+          'node',
+          'bar',
+          'alpha',
+          { fizz: 'buzz' },
+        ));
+
+        const actions = store.getActions();
+
+        expect(actions[0]).toMatchObject({
+          type: actionTypes.UPDATE_VARIABLE,
+          meta: {
+            entity: 'node',
+            type: 'bar',
+            variable: 'alpha',
+          },
+          configuration: { fizz: 'buzz' },
+        });
+      });
+
+      it('throws an error if the variable does not already exist', () => {
+        const createAction = actionCreators.updateVariable('node', 'bar', 'xenon', { name: 'XENON' });
+        const store = mockStore(testState);
+
+        expect(() => {
+          store.dispatch(createAction);
+        }).toThrow(new Error('Variable "xenon" does not exist'));
       });
     });
 

--- a/src/ducks/modules/protocol/codebook.js
+++ b/src/ducks/modules/protocol/codebook.js
@@ -115,6 +115,8 @@ const createVariableThunk = (entity, type, configuration) =>
     const variableNameExists = Object.values(variables)
       .some(({ name }) => name === configuration.name);
 
+    // console.log('HI IT ME', { variables, values: Object.values(variables), variableNameExists });
+
     // We can't use same variable name twice.
     if (variableNameExists) {
       throw new Error(`Variable with name "${configuration.name}" already exists`);
@@ -303,6 +305,7 @@ const testing = {
   createType,
   deleteType,
   createVariable,
+  updateVariable,
   deleteVariable,
 };
 

--- a/src/ducks/modules/protocol/codebook.js
+++ b/src/ducks/modules/protocol/codebook.js
@@ -122,7 +122,7 @@ const createEdgeThunk = configuration =>
 const createVariableThunk = (entity, type, configuration) =>
   (dispatch, getState) => {
     const variables = getVariablesForSubject(getState(), { entity, type });
-    const variableNameExists = variables
+    const variableNameExists = Object.values(variables)
       .some(({ name }) => name === configuration.name);
 
     // We can't use same variable name twice.

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -1,73 +1,7 @@
-/* eslint-disable import/prefer-default-export */
-
-import { get, reduce, isArray, values } from 'lodash';
+import { isArray, values } from 'lodash';
 import { createSelector } from 'reselect';
 import { getProtocol } from './protocol';
-
-/**
- * Collect nodes that match path from `obj`
- *
- * Example usage:
- *
- * ```
- * const myObject = {
- *   stages: [
- *     {
- *       prompts: [
- *         { variable: 'foo' },
- *         { variable: 'bar' },
- *       ]
- *     },
- *     {
- *       prompts: [
- *         { variable: 'bazz' },
- *       ]
- *     },
- *   ]
- * };
- *
- * const paths = collectPaths('stages[].prompts[].variable', myObject);
- * // result:
- * // paths = {
- * //   'stages[0].prompts[0].variable': 'foo',
- * //   'stages[0].prompts[1].variable': 'bar',
- * //   'stages[1].prompts[0].variable': 'bazz',
- * // };
- * ```
- *
- * @returns {object} in format: { [path]: node }
- */
-const collectPaths = (paths, obj, memoPath) => {
-  // We expect a string notation for paths, but it's actually converted to array automatically:
-  // 'stages[].prompts[].subject.type' => ['stages', 'prompts', 'subject.type']
-  const [next, ...rest] = isArray(paths) ?
-    paths :
-    paths.split('[].');
-
-  const path = memoPath ?
-    `${memoPath}.${next}` : `${next}`;
-
-  const nextObj = get(obj, next);
-
-  if (rest.length > 0) {
-    return reduce(
-      nextObj || [],
-      (memo, item, index) => ({
-        ...memo,
-        ...collectPaths(rest, item, `${path}[${index}]`),
-      }),
-      {},
-    );
-  }
-
-  if (nextObj) {
-    return {
-      [path]: nextObj,
-    };
-  }
-
-  return {};
-};
+import collectPaths from '../utils/collectPaths';
 
 /**
  * Returns index of used variables

--- a/src/utils/collectPaths.js
+++ b/src/utils/collectPaths.js
@@ -1,0 +1,68 @@
+import { get, reduce, isArray } from 'lodash';
+
+/**
+ * Collect nodes that match path from `obj`
+ *
+ * Example usage:
+ *
+ * ```
+ * const myObject = {
+ *   stages: [
+ *     {
+ *       prompts: [
+ *         { variable: 'foo' },
+ *         { variable: 'bar' },
+ *       ]
+ *     },
+ *     {
+ *       prompts: [
+ *         { variable: 'bazz' },
+ *       ]
+ *     },
+ *   ]
+ * };
+ *
+ * const paths = collectPaths('stages[].prompts[].variable', myObject);
+ * // result:
+ * // paths = {
+ * //   'stages[0].prompts[0].variable': 'foo',
+ * //   'stages[0].prompts[1].variable': 'bar',
+ * //   'stages[1].prompts[0].variable': 'bazz',
+ * // };
+ * ```
+ *
+ * @returns {object} in format: { [path]: node }
+ */
+const collectPaths = (paths, obj, memoPath) => {
+  // We expect a string notation for paths, but it's actually converted to array automatically:
+  // 'stages[].prompts[].subject.type' => ['stages', 'prompts', 'subject.type']
+  const [next, ...rest] = isArray(paths) ?
+    paths :
+    paths.split('[].');
+
+  const path = memoPath ?
+    `${memoPath}.${next}` : `${next}`;
+
+  const nextObj = get(obj, next);
+
+  if (rest.length > 0) {
+    return reduce(
+      nextObj || [],
+      (memo, item, index) => ({
+        ...memo,
+        ...collectPaths(rest, item, `${path}[${index}]`),
+      }),
+      {},
+    );
+  }
+
+  if (nextObj) {
+    return {
+      [path]: nextObj,
+    };
+  }
+
+  return {};
+};
+
+export default collectPaths;

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -37,6 +37,19 @@ export const maxSelected = max =>
   value =>
     (!value || coerceArray(value).length > max ? `Must choose ${max} or less` : undefined);
 
+export const validateName = (value, allValues, { existingVariableNames = [] }) => {
+  const validateRequired = required();
+  if (validateRequired(value)) { return validateRequired(value); }
+
+  if (!value) { return undefined; }
+
+  const isUsed = existingVariableNames
+    .some(name => name.toLowerCase() === value.toLowerCase());
+  if (isUsed) { return `Variable name "${value}" is already used elsewhere`; }
+
+  return undefined;
+};
+
 const validations = {
   required,
   requiredAcceptsNull,
@@ -46,6 +59,7 @@ const validations = {
   maxValue,
   minSelected,
   maxSelected,
+  validateName,
 };
 
 /**


### PR DESCRIPTION
Adds field validation for variable creation that checks against existing variable names (case insensitive).

RE enforcing this for the creatable option type: in my testing this already wasn't possible  as the existing variable will be selected. We can use the `isValidNewOption` prop if that turns out to be incorrect (https://react-select.com/props#creatable-props).

Resolves #471