### PR TITLE
Prevent deleting used assets

### DIFF
--- a/src/__tests__/testState.json
+++ b/src/__tests__/testState.json
@@ -13,6 +13,18 @@
       "assetManifest": {
         "1234-asset-1": {
           "source": "1234-4567-asset-1"
+        },
+        "1234-asset-2": {
+          "source": "1234-4567-asset-2"
+        },
+        "1234-asset-3": {
+          "source": "1234-4567-asset-3"
+        },
+        "1234-asset-4": {
+          "source": "1234-4567-asset-4"
+        },
+        "1234-asset-5": {
+          "source": "1234-4567-asset-5"
         }
       },
       "codebook": {
@@ -134,6 +146,21 @@
               "id": "oscar"
             }
           ]
+        },
+        {
+          "id": "assets",
+          "panels": [
+            { "dataSource": "1234-asset-2" }
+          ],
+          "prompts": [
+            { "dataSource" : "1234-asset-3" }
+          ],
+          "items": [
+            { "content": "1234-asset-4" }
+          ],
+          "background": {
+            "image": "1234-asset-5"
+          }
         }
       ]
     }

--- a/src/components/AssetBrowser/Asset.js
+++ b/src/components/AssetBrowser/Asset.js
@@ -61,7 +61,7 @@ class Asset extends Component {
       </div>
     );
   }
-};
+}
 
 Asset.propTypes = {
   id: PropTypes.string.isRequired,

--- a/src/components/AssetBrowser/Asset.js
+++ b/src/components/AssetBrowser/Asset.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import Icon from '../../ui/components/Icon';
 import * as Assets from '../Assets';
 
@@ -14,45 +15,58 @@ const ASSET_COMPONENTS = {
   network: Assets.Network,
 };
 
-const Asset = ({
-  id,
-  onClick,
-  onDelete,
-  type,
-}) => {
-  const PreviewComponent = ASSET_COMPONENTS[type] || FallBackAssetComponent;
+class Asset extends Component {
+  handleClick = () => this.props.onClick(this.props.id);
 
-  const handleClick = () => onClick(id);
-
-  const handleDelete = (e) => {
+  handleDelete = (e) => {
+    const { isUsed, onDelete, id } = this.props;
     e.stopPropagation();
-    onDelete(id);
+
+    onDelete(id, isUsed);
   };
 
-  return (
-    <div
-      onClick={handleClick}
-      className="asset-browser-asset"
-    >
-      <div className="asset-browser-asset__preview">
-        <PreviewComponent id={id} />
-      </div>
+  render() {
+    const {
+      id,
+      onDelete,
+      type,
+      isUsed,
+    } = this.props;
 
-      { onDelete &&
-        <div
-          className="asset-browser-asset__delete"
-          onClick={handleDelete}
-        >
-          <Icon name="delete" />
+    const PreviewComponent = ASSET_COMPONENTS[type] || FallBackAssetComponent;
+
+    const deleteClasses = cx(
+      'asset-browser-asset__delete',
+      { 'asset-browser-asset__delete--is-used': isUsed },
+    );
+
+    return (
+      <div
+        onClick={this.handleClick}
+        className="asset-browser-asset"
+      >
+        <div className="asset-browser-asset__preview">
+          <PreviewComponent id={id} />
         </div>
-      }
-    </div>
-  );
+
+        { onDelete &&
+          <div
+            className={deleteClasses}
+            onClick={this.handleDelete}
+            title={isUsed ? 'This asset is in use by the protocol and cannot be deleted' : ''}
+          >
+            <Icon name="delete" />
+          </div>
+        }
+      </div>
+    );
+  }
 };
 
 Asset.propTypes = {
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
+  isUsed: PropTypes.bool,
   onClick: PropTypes.func,
   onDelete: PropTypes.func,
 };
@@ -60,6 +74,7 @@ Asset.propTypes = {
 Asset.defaultProps = {
   onClick: () => {},
   onDelete: null,
+  isUsed: false,
 };
 
 export default Asset;

--- a/src/components/AssetBrowser/Asset.js
+++ b/src/components/AssetBrowser/Asset.js
@@ -35,15 +35,15 @@ class Asset extends Component {
 
     const PreviewComponent = ASSET_COMPONENTS[type] || FallBackAssetComponent;
 
-    const deleteClasses = cx(
-      'asset-browser-asset__delete',
-      { 'asset-browser-asset__delete--is-used': isUsed },
+    const assetClasses = cx(
+      'asset-browser-asset',
+      { 'asset-browser-asset--is-used': isUsed },
     );
 
     return (
       <div
         onClick={this.handleClick}
-        className="asset-browser-asset"
+        className={assetClasses}
       >
         <div className="asset-browser-asset__preview">
           <PreviewComponent id={id} />
@@ -51,7 +51,7 @@ class Asset extends Component {
 
         { onDelete &&
           <div
-            className={deleteClasses}
+            className="asset-browser-asset__delete"
             onClick={this.handleDelete}
             title={isUsed ? 'This asset is in use by the protocol and cannot be deleted' : ''}
           >

--- a/src/components/AssetBrowser/withAssetActions.js
+++ b/src/components/AssetBrowser/withAssetActions.js
@@ -16,9 +16,18 @@ const connectActions = connect(
 
 const assetHandlers = withHandlers({
   onDelete: ({ deleteAsset, openDialog }) =>
-    (assetId) => {
+    (assetId, isUsed = false) => {
+      if (isUsed) {
+        openDialog({
+          type: 'Notice',
+          title: 'Cannot delete asset',
+          message: 'Cannot delete this asset because it is used by the protocol.',
+          confirmLabel: 'Ok',
+        });
+        return;
+      }
+
       openDialog({
-        id: '1234-1234-1',
         type: 'Confirm',
         title: 'Delete Asset',
         message: 'Are you sure you want to delete this asset?',

--- a/src/components/AssetBrowser/withAssets.js
+++ b/src/components/AssetBrowser/withAssets.js
@@ -9,6 +9,7 @@ import {
   withHandlers,
 } from 'recompose';
 import { getAssetManifest } from '../../selectors/protocol';
+import { getAssetIndex, utils as indexUtils } from '../../selectors/indexes';
 
 const filterByAssetType = (assetType, assets) => (
   assetType ?
@@ -31,10 +32,25 @@ const filterHandlers = withHandlers({
 });
 
 const mapStateToProps = (state, { assetType }) => {
-  const assets = getAssetManifest(state);
+  const allAssets = getAssetManifest(state);
+  const filteredAssets = filterAssets(assetType, allAssets);
+
+  // Get asset usage index
+  const assetIndex = getAssetIndex(state);
+  const assetSearch = indexUtils.buildSearch([assetIndex]);
+
+  // Check for asset usage
+  const assets = filteredAssets.map((asset) => {
+    if (!assetSearch.has(asset.id)) { return asset; }
+
+    return {
+      ...asset,
+      isUsed: true,
+    };
+  });
 
   return {
-    assets: filterAssets(assetType, assets),
+    assets,
   };
 };
 

--- a/src/selectors/__tests__/__snapshots__/indexes.test.js.snap
+++ b/src/selectors/__tests__/__snapshots__/indexes.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`indexes selectors getAssetIndex() extracts asset references into index 1`] = `
+Object {
+  "stages[6].background.image": "1234-asset-5",
+  "stages[6].items[0].content": "1234-asset-4",
+  "stages[6].panels[0].dataSource": "1234-asset-2",
+  "stages[6].prompts[0].dataSource": "1234-asset-3",
+}
+`;
+
 exports[`indexes selectors getVariableIndex() extracts variables into index 1`] = `
 Object {
   "stages[0].prompts[0].form.fields[0].variable": "alpha",

--- a/src/selectors/__tests__/indexes.test.js
+++ b/src/selectors/__tests__/indexes.test.js
@@ -4,18 +4,11 @@ import testState from '../../__tests__/testState.json';
 
 import {
   getVariableIndex,
+  getAssetIndex,
   utils,
 } from '../indexes';
 
 describe('indexes selectors', () => {
-  describe('getVariableIndex()', () => {
-    it('extracts variables into index', () => {
-      const subject = getVariableIndex(testState);
-
-      expect(subject).toMatchSnapshot();
-    });
-  });
-
   describe('utils.buildSearch()', () => {
     it('correctly builds the Set', () => {
       const index1 = {
@@ -37,6 +30,22 @@ describe('indexes selectors', () => {
       const search = utils.buildSearch([index1, index2], [excludeList]);
 
       expect(search).toEqual(new Set([1, 2, 4, 5, 6]));
+    });
+  });
+
+  describe('getVariableIndex()', () => {
+    it('extracts variables into index', () => {
+      const subject = getVariableIndex(testState);
+
+      expect(subject).toMatchSnapshot();
+    });
+  });
+
+  describe('getAssetIndex()', () => {
+    it('extracts asset references into index', () => {
+      const subject = getAssetIndex(testState);
+
+      expect(subject).toMatchSnapshot();
     });
   });
 });

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -106,7 +106,7 @@ const getAssetIndex = createSelector(
   getProtocol,
   (protocol) => {
     const informationItems = collectPaths('stages[].items[].content', protocol);
-    const nameGeneratorPanels = collectPaths('stages[].prompts[].panels[].dataSource', protocol);
+    const nameGeneratorPanels = collectPaths('stages[].panels[].dataSource', protocol);
     const nameGeneratorDataSources = collectPaths('stages[].prompts[].dataSource', protocol);
     const sociogramBackground = collectPaths('stages[].background.image', protocol);
 

--- a/src/selectors/indexes.js
+++ b/src/selectors/indexes.js
@@ -92,6 +92,33 @@ const getVariableIndex = createSelector(
   },
 );
 
+
+/**
+ * Returns index of used assets
+ * Checks for usage in the following:
+ * - `stages[].prompts[].items[].content`
+ * - `stages[].prompts[].panels[].dataSource`
+ * - `stages[].prompts[].dataSource`
+ * - `stages[].background.image`
+ * @returns {object} in format: { [path]: variable }
+ */
+const getAssetIndex = createSelector(
+  getProtocol,
+  (protocol) => {
+    const informationItems = collectPaths('stages[].items[].content', protocol);
+    const nameGeneratorPanels = collectPaths('stages[].prompts[].panels[].dataSource', protocol);
+    const nameGeneratorDataSources = collectPaths('stages[].prompts[].dataSource', protocol);
+    const sociogramBackground = collectPaths('stages[].background.image', protocol);
+
+    return {
+      ...informationItems,
+      ...nameGeneratorPanels,
+      ...nameGeneratorDataSources,
+      ...sociogramBackground,
+    };
+  },
+);
+
 const combineLists = lists =>
   lists
     .map(list => (!isArray(list) ? values(list) : list))
@@ -122,5 +149,6 @@ const utils = {
 
 export {
   getVariableIndex,
+  getAssetIndex,
   utils,
 };

--- a/src/styles/components/_badge.scss
+++ b/src/styles/components/_badge.scss
@@ -1,4 +1,4 @@
-.badge {
+%badge {
   display: inline-flex;
   background-color: var(--color-mid-grey);
   border-radius: unit(.5);
@@ -7,4 +7,8 @@
   font-size: .7rem;
   color: var(--text-light);
   text-transform: capitalize;
+}
+
+.badge {
+  @extend %badge;
 }

--- a/src/styles/components/asset-browser/_asset.scss
+++ b/src/styles/components/asset-browser/_asset.scss
@@ -34,8 +34,8 @@
 
   &__delete {
     position: absolute;
-    top: unit(.5);
-    right: unit(.5);
+    top: unit(.75);
+    right: unit(.75);
     width: unit(2.6);
     height: unit(2.6);
     border-radius: unit(2.6);
@@ -73,14 +73,13 @@
   }
 
   &::after {
-    content: 'unused';
+    @extend %badge;
+    content: 'Unused';
     position: absolute;
-    top: unit(.5);
-    left: unit(.5);
-    background: var(--architect-active);
-    color: var(--text-light);
-    border-radius: unit(1);
-    padding: unit(.25) unit(.75);
+    margin: 0;
+    bottom: unit(.75);
+    left: unit(.75);
+    background: var(--error);
   }
 
   &--is-used {

--- a/src/styles/components/asset-browser/_asset.scss
+++ b/src/styles/components/asset-browser/_asset.scss
@@ -70,5 +70,9 @@
         }
       }
     }
+
+    &--is-used {
+      cursor: not-allowed;
+    }
   }
 }

--- a/src/styles/components/asset-browser/_asset.scss
+++ b/src/styles/components/asset-browser/_asset.scss
@@ -70,9 +70,26 @@
         }
       }
     }
+  }
 
-    &--is-used {
+  &::after {
+    content: 'unused';
+    position: absolute;
+    top: unit(.5);
+    left: unit(.5);
+    background: var(--architect-active);
+    color: var(--text-light);
+    border-radius: unit(1);
+    padding: unit(.25) unit(.75);
+  }
+
+  &--is-used {
+    .asset-browser-asset__delete {
       cursor: not-allowed;
+    }
+
+    &::after {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
This updates asset browser UI as follows:

  - Show not-allowed cursor, and tooltip text for in use assets on delete button
  - If delete button is clicked, show further explanation in an info dialog
  - Show an "unused" tag on unused assets.

### Known issues
Messages are generic, i.e. do not explain where usage is occuring. That information is available in the backend (in the form of a path e.g. `stages[1].prompts[2].dataSource`), considering that this info is quite awkward to explain perhaps we could give a top-level notice about which screens it is used on.

Resolves: #475  