### PR TITLE
make component a required variable property for select option on name…

### DIFF
--- a/src/components/sections/CategoricalBinPrompts/withPromptProps.js
+++ b/src/components/sections/CategoricalBinPrompts/withPromptProps.js
@@ -1,11 +1,23 @@
 import { connect } from 'react-redux';
 import { change } from 'redux-form';
 import { compose, withHandlers } from 'recompose';
-import { getVariableOptionsForSubject } from '../../../selectors/codebook';
+import { pickBy, reduce } from 'lodash';
+import { getVariablesForSubject } from '../../../selectors/codebook';
 import { actionCreators as codebookActions } from '../../../ducks/modules/protocol/codebook';
 
 const mapStateToProps = (state, { type, entity }) => {
-  const variableOptions = getVariableOptionsForSubject(state, { type, entity });
+  const existingVariables = getVariablesForSubject(state, { type, entity });
+
+  const variablesWithoutComponents = pickBy(existingVariables, value => !value.component);
+
+  const variableOptions = reduce(
+    variablesWithoutComponents,
+    (acc, { name, type: variableType }, variableId) => ([
+      ...acc,
+      { type: variableType, label: name, value: variableId },
+    ]),
+    [],
+  );
 
   return {
     variableOptions,

--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -42,7 +42,7 @@ const PromptFields = ({
         onCreateOption={createNewVariable} // reset later fields, create variable of no type?
         onChange={handleChangeVariable} // read/reset component options validation
         validation={{ required: true }}
-        placeholder="Type to create a variable..."
+        placeholder="Type to create a new variable, or select an existing one from the list..."
         formatCreateLabel={inputValue => (
           <span>
             Press enter to create a variable named &quot;{inputValue}&quot;.

--- a/src/components/sections/Form/withFieldsHandlers.js
+++ b/src/components/sections/Form/withFieldsHandlers.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { reduce, get } from 'lodash';
+import { reduce, get, pickBy } from 'lodash';
 import { formValueSelector, change } from 'redux-form';
 import { compose, withHandlers } from 'recompose';
 import { getVariablesForSubject } from '../../../selectors/codebook';
@@ -13,8 +13,10 @@ const mapStateToProps = (state, { form, entity, type }) => {
 
   const existingVariables = getVariablesForSubject(state, { entity, type });
 
+  const variablesWithComponents = pickBy(existingVariables, value => value.component);
+
   const variableOptions = reduce(
-    existingVariables,
+    variablesWithComponents,
     (acc, { name }, variableId) => ([
       ...acc,
       { label: name, value: variableId },
@@ -28,7 +30,7 @@ const mapStateToProps = (state, { form, entity, type }) => {
     variable,
     variableType,
     variableOptions,
-    existingVariables,
+    variablesWithComponents,
   };
 };
 
@@ -50,12 +52,12 @@ const fieldsHandlers = withHandlers({
       const { variable } = createVariable(entity, type, { name });
       return variable;
     },
-  handleChangeVariable: ({ existingVariables, changeField, form }) =>
+  handleChangeVariable: ({ variablesWithComponents, changeField, form }) =>
     (_, value) => {
       // Either load settings from codebook, or reset
-      const options = get(existingVariables, [value, 'options'], null);
-      const validation = get(existingVariables, [value, 'validation'], {});
-      const component = get(existingVariables, [value, 'component'], null);
+      const options = get(variablesWithComponents, [value, 'options'], null);
+      const validation = get(variablesWithComponents, [value, 'validation'], {});
+      const component = get(variablesWithComponents, [value, 'component'], null);
 
       // component?
       changeField(form, 'component', component);


### PR DESCRIPTION
Fixes #501 

From Slack:


>Having thought about this a bit more, I think what we actually need to do is to exclude variables that do not have an input type (and were therefore not defined on a node form) from the select box for node form variables.
>
>Reason is simple: if I create an ordinal variable on an ordinal bin (without an input type), and then add it to a name generator form, and then _change_ the type, it will invalidate the ordinal bin interface entirely.
>
>For the same reason, I think the ordinal bin interface should exclude ordinal variables that _have an input type_ from its select box.

Issues:

- causes a crash when the participant types an existing variable name (that is filtered from the list because it doesn't have a component) and presses enter.
- doesn't work for creating a new variable (which of course has no input component set yet!)