### PR TITLE
Fix/immutable variable type

### DIFF
--- a/src/components/Form/inputOptions.js
+++ b/src/components/Form/inputOptions.js
@@ -1,4 +1,4 @@
-import { values } from 'lodash';
+import { keys, values } from 'lodash';
 
 const VARIABLE_TYPES = {
   number: {
@@ -67,6 +67,8 @@ const VARIABLE_TYPES_WITH_OPTIONS = [
   'categorical',
 ];
 
+const VARIABLE_TYPES_WITH_COMPONENTS = keys(VARIABLE_TYPES);
+
 const getComponentsForType = (type) => {
   switch (type) {
     case 'number':
@@ -129,6 +131,7 @@ const getColorForType = (type) => {
 export {
   COMPONENTS,
   VARIABLE_TYPES_WITH_OPTIONS,
+  VARIABLE_TYPES_WITH_COMPONENTS,
   inputOptions,
   variableOptions,
   getTypeForComponent,

--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -111,6 +111,7 @@ PromptFields.propTypes = {
   variableType: PropTypes.string,
   handleChangeComponent: PropTypes.func.isRequired,
   variableOptions: PropTypes.array,
+  componentOptions: PropTypes.array,
   createNewVariable: PropTypes.func.isRequired,
   handleChangeVariable: PropTypes.func.isRequired,
 };
@@ -119,6 +120,7 @@ PromptFields.defaultProps = {
   variable: null,
   variableType: null,
   variableOptions: null,
+  componentOptions: null,
 };
 
 export { PromptFields };

--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -9,7 +9,7 @@ import CreatableSelect from '../../Form/Fields/CreatableSelect';
 import Options from '../../Options';
 import Validations from '../../Validations';
 import SelectOptionImage from '../../Form/Fields/SelectOptionImage';
-import inputOptions, { isVariableTypeWithOptions } from '../../Form/inputOptions';
+import { isVariableTypeWithOptions } from '../../Form/inputOptions';
 import Row from '../Row';
 import Section from '../Section';
 import withFieldsMeta from './withFieldsHandlers';
@@ -19,6 +19,7 @@ const PromptFields = ({
   variable,
   variableType,
   variableOptions,
+  componentOptions,
   createNewVariable,
   handleChangeComponent,
   handleChangeVariable,
@@ -68,7 +69,7 @@ const PromptFields = ({
           name="component"
           component={Select}
           placeholder="Select component"
-          options={inputOptions}
+          options={componentOptions}
           selectOptionComponent={SelectOptionImage}
           validation={{ required: true }}
           onChange={handleChangeComponent}

--- a/src/components/sections/Form/withFieldsHandlers.js
+++ b/src/components/sections/Form/withFieldsHandlers.js
@@ -3,7 +3,11 @@ import { reduce, get } from 'lodash';
 import { formValueSelector, change } from 'redux-form';
 import { compose, withHandlers } from 'recompose';
 import { getVariablesForSubject } from '../../../selectors/codebook';
-import { getTypeForComponent } from '../../Form/inputOptions';
+import inputOptions, {
+  getTypeForComponent,
+  getComponentsForType,
+  VARIABLE_TYPES_WITH_COMPONENTS,
+} from '../../Form/inputOptions';
 import { actionCreators as codebookActions } from '../../../ducks/modules/protocol/codebook';
 
 const mapStateToProps = (state, { form, entity, type }) => {
@@ -15,19 +19,38 @@ const mapStateToProps = (state, { form, entity, type }) => {
 
   const variableOptions = reduce(
     existingVariables,
-    (acc, { name }, variableId) => ([
-      ...acc,
-      { label: name, value: variableId },
-    ]),
+    (acc, { name, type: variableType }, variableId) => {
+      // If not a variable with corresponding component, we can't
+      // use it here.
+      if (variableType && !VARIABLE_TYPES_WITH_COMPONENTS.includes(variableType)) { return acc; }
+
+      return [
+        ...acc,
+        { label: name, value: variableId },
+      ];
+    },
     [],
   );
 
-  const variableType = getTypeForComponent(component);
+  // 1. If type defined use that (existing variable)
+  // 2. Othewise derive it from component (new variable)
+  const variableType = get(
+    existingVariables,
+    [variable, 'type'],
+    getTypeForComponent(component),
+  );
+
+  // 1. If type defined, show components that match (existing variable)
+  // 2. Othewise list all inputOptions (new variable)
+  const componentOptions = variableType ?
+    getComponentsForType(variableType) :
+    inputOptions;
 
   return {
     variable,
     variableType,
     variableOptions,
+    componentOptions,
     existingVariables,
   };
 };
@@ -40,10 +63,14 @@ const mapDispatchToProps = {
 const fieldsState = connect(mapStateToProps, mapDispatchToProps);
 
 const fieldsHandlers = withHandlers({
-  handleChangeComponent: ({ changeField, form }) =>
-    () => {
-      changeField(form, 'options', null);
-      changeField(form, 'validation', {});
+  handleChangeComponent: ({ changeField, form, variableType }) =>
+    (e, value) => {
+      // Only reset if type not defined (new variable)
+      const componentType = getTypeForComponent(value);
+      if (variableType !== componentType) {
+        changeField(form, 'options', null);
+        changeField(form, 'validation', {});
+      }
     },
   createNewVariable: ({ createVariable, entity, type }) =>
     (name) => {


### PR DESCRIPTION
Ensures that variable type is not changed by the form field editor after it has been set in the codebook.

Resolves issues outlined here: https://github.com/codaco/Architect/pull/503