### PR TITLE
Allow additional classes on Section component

### DIFF
--- a/src/components/sections/EdgeType/withDisableAndReset.js
+++ b/src/components/sections/EdgeType/withDisableAndReset.js
@@ -33,7 +33,7 @@ const withResetHandlers = withHandlers({
       openDialog({
         type: 'Confirm',
         title: 'Change edge type for this stage',
-        message: 'You attemped to change the edge type of a stage that you have already configured. Before you can procede the stage must be reset, which will remove any existing configuration. Do you want to reset the stage now?',
+        message: 'You attemped to change the edge type of a stage that you have already configured. Before you can proceed the stage must be reset, which will remove any existing configuration. Do you want to reset the stage now?',
         onConfirm: resetStage,
         confirmLabel: 'Continue',
       });

--- a/src/components/sections/NodeType/withDisableAndReset.js
+++ b/src/components/sections/NodeType/withDisableAndReset.js
@@ -33,7 +33,7 @@ const withResetHandlers = withHandlers({
       openDialog({
         type: 'Confirm',
         title: 'Change node type for this stage',
-        message: 'You attemped to change the node type of a stage that you have already configured. Before you can procede the stage must be reset, which will remove any existing configuration. Do you want to reset the stage now?',
+        message: 'You attemped to change the node type of a stage that you have already configured. Before you can proceed the stage must be reset, which will remove any existing configuration. Do you want to reset the stage now?',
         onConfirm: resetStage,
         confirmLabel: 'Continue',
       });

--- a/src/components/sections/Section.js
+++ b/src/components/sections/Section.js
@@ -8,10 +8,12 @@ const Section = ({
   group,
   compactNext,
   children,
+  className,
   contentId,
   focus,
 }) => {
   const sectionClasses = cx(
+    className,
     'stage-editor-section',
     { 'stage-editor-section--disabled': disabled },
     { 'stage-editor-section--group': group },
@@ -43,6 +45,7 @@ Section.propTypes = {
   disabled: PropTypes.bool,
   group: PropTypes.bool,
   compactNext: PropTypes.bool,
+  className: PropTypes.string,
   contentId: PropTypes.string,
   focus: PropTypes.bool,
   children: PropTypes.node.isRequired,
@@ -52,6 +55,7 @@ Section.defaultProps = {
   contentId: null,
   disabled: false,
   group: false,
+  className: '',
   focus: false,
   compactNext: false,
 };


### PR DESCRIPTION
Resolves #510 "cancel on changing nodetype doesn't cancel nodetype change "

This restores the original functionality of this feature, and might not be the fix you were expecting:
- When a node is selected pointer events are disabled (preventing the contained UI, node types, buttons from being clicked)
- When clicking on this section (anywhere), the dialog is shown:
  - Clicking cancel does nothing
  - Clicking confirm **resets** the nodeType, meaning that the UI is no longer disabled. You must then click again on any button/node you original intended to click.


