### PR TITLE
defaults for skiplogic

### DIFF
--- a/src/components/Query/Query.js
+++ b/src/components/Query/Query.js
@@ -16,9 +16,13 @@ const Query = ({ rules, join, codebook, onChange, openDialog }) => (
 Query.propTypes = {
   onChange: PropTypes.func.isRequired,
   openDialog: PropTypes.func.isRequired,
-  rules: PropTypes.array.isRequired,
+  rules: PropTypes.array,
   codebook: PropTypes.object.isRequired,
   join: PropTypes.string.isRequired,
+};
+
+Query.defaultProps = {
+  rules: [],
 };
 
 export { Query };

--- a/src/components/SkipLogicEditor/index.js
+++ b/src/components/SkipLogicEditor/index.js
@@ -10,7 +10,7 @@ import { actionCreators as stageActions } from '../../ducks/modules/protocol/sta
 const defaultLogic = {
   action: 'SKIP',
   filter: {
-    join: '',
+    join: 'AND',
     rules: [],
   },
 };


### PR DESCRIPTION
This makes sure there is a default for join and rules, so there isn't a protocol-validation error later when saving the protocol.