### PR TITLE
make sure name is updated instead of duplicated

### DIFF
--- a/src/components/sections/Form/withFieldsHandlers.js
+++ b/src/components/sections/Form/withFieldsHandlers.js
@@ -74,11 +74,13 @@ const fieldsHandlers = withHandlers({
   handleChangeVariable: ({ existingVariables, changeField, form }) =>
     (_, value) => {
       // Either load settings from codebook, or reset
+      const name = get(existingVariables, [value, 'name'], null);
       const options = get(existingVariables, [value, 'options'], null);
       const validation = get(existingVariables, [value, 'validation'], {});
       const component = get(existingVariables, [value, 'component'], null);
 
       // component?
+      changeField(form, 'name', name);
       changeField(form, 'component', component);
       changeField(form, 'options', options);
       changeField(form, 'validation', validation);


### PR DESCRIPTION
Fixes #538. To test, create a name generator with a form and a couple of fields and look at the codebook. Edit a field to change the variable, and make sure the codebook still has the correct number of variables with the expected values.