### PR TITLE
Remove name property from Form handlers

### DIFF
--- a/src/components/sections/Form/helpers.js
+++ b/src/components/sections/Form/helpers.js
@@ -3,7 +3,7 @@ import { formValueSelector } from 'redux-form';
 import { omit, get, reduce } from 'lodash';
 import { getVariablesForSubject } from '../../../selectors/codebook';
 
-export const CODEBOOK_PROPERTIES = ['name', 'options', 'component', 'validation'];
+export const CODEBOOK_PROPERTIES = ['options', 'component', 'validation'];
 
 export const getCodebookProperties = properties =>
   reduce(

--- a/src/components/sections/Form/withFieldsHandlers.js
+++ b/src/components/sections/Form/withFieldsHandlers.js
@@ -74,13 +74,11 @@ const fieldsHandlers = withHandlers({
   handleChangeVariable: ({ existingVariables, changeField, form }) =>
     (_, value) => {
       // Either load settings from codebook, or reset
-      const name = get(existingVariables, [value, 'name'], null);
       const options = get(existingVariables, [value, 'options'], null);
       const validation = get(existingVariables, [value, 'validation'], {});
       const component = get(existingVariables, [value, 'component'], null);
 
       // component?
-      changeField(form, 'name', name);
       changeField(form, 'component', component);
       changeField(form, 'options', options);
       changeField(form, 'validation', validation);


### PR DESCRIPTION
Another fix for #538.

This form should not be setting a name value at all, as it's not a configurable field here.

Now that we have a merge handler in updateVariable we can just omit it completely.