### PR TITLE
Don't create variables without a type

### DIFF
--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -13,6 +13,7 @@ import { isVariableTypeWithOptions } from '../../Form/inputOptions';
 import Row from '../Row';
 import Section from '../Section';
 import withFieldsHandlers from './withFieldsHandlers';
+import { normalizeKeyDown } from '../../enhancers/withCreateVariableHandler';
 
 const PromptFields = ({
   form,
@@ -20,10 +21,9 @@ const PromptFields = ({
   variableType,
   variableOptions,
   componentOptions,
-  handleCreateVariable,
+  handleNewVariable,
   handleChangeComponent,
   handleChangeVariable,
-  normalizeKeyDown,
 }) => (
   <Section>
     <Row contentId="guidance.section.form.field.name">
@@ -41,7 +41,7 @@ const PromptFields = ({
         name="variable"
         component={CreatableSelect}
         options={variableOptions} // from variables
-        onCreateOption={handleCreateVariable} // reset later fields, create variable of no type?
+        onCreateOption={handleNewVariable} // reset later fields, create variable of no type?
         onChange={handleChangeVariable} // read/reset component options validation
         onKeyDown={normalizeKeyDown}
         validation={{ required: true }}
@@ -114,9 +114,8 @@ PromptFields.propTypes = {
   handleChangeComponent: PropTypes.func.isRequired,
   variableOptions: PropTypes.array,
   componentOptions: PropTypes.array,
-  handleCreateVariable: PropTypes.func.isRequired,
+  handleNewVariable: PropTypes.func.isRequired,
   handleChangeVariable: PropTypes.func.isRequired,
-  normalizeKeyDown: PropTypes.func.isRequired,
 };
 
 PromptFields.defaultProps = {

--- a/src/components/sections/Form/withFieldsHandlers.js
+++ b/src/components/sections/Form/withFieldsHandlers.js
@@ -1,19 +1,22 @@
 import { connect } from 'react-redux';
-import { reduce, get } from 'lodash';
+import { reduce, get, has } from 'lodash';
 import { formValueSelector, change } from 'redux-form';
-import { compose, withHandlers } from 'recompose';
+import {
+  compose,
+  withHandlers,
+} from 'recompose';
 import { getVariablesForSubject } from '../../../selectors/codebook';
 import inputOptions, {
   getTypeForComponent,
   getComponentsForType,
   VARIABLE_TYPES_WITH_COMPONENTS,
 } from '../../Form/inputOptions';
-import withCreateVariableHandler from '../../enhancers/withCreateVariableHandler';
 
 const mapStateToProps = (state, { form, entity, type }) => {
   const formSelector = formValueSelector(form);
   const variable = formSelector(state, 'variable');
   const component = formSelector(state, 'component');
+  const createNewVariable = formSelector(state, '_createNewVariable');
 
   const existingVariables = getVariablesForSubject(state, { entity, type });
 
@@ -32,6 +35,10 @@ const mapStateToProps = (state, { form, entity, type }) => {
     [],
   );
 
+  const variableOptionsWithNewVariable = createNewVariable ?
+    [...variableOptions, { label: createNewVariable, value: createNewVariable }] :
+    variableOptions;
+
   // 1. If type defined use that (existing variable)
   // 2. Othewise derive it from component (new variable)
   const variableType = get(
@@ -49,7 +56,7 @@ const mapStateToProps = (state, { form, entity, type }) => {
   return {
     variable,
     variableType,
-    variableOptions,
+    variableOptions: variableOptionsWithNewVariable,
     componentOptions,
     existingVariables,
   };
@@ -78,10 +85,18 @@ const fieldsHandlers = withHandlers({
       const validation = get(existingVariables, [value, 'validation'], {});
       const component = get(existingVariables, [value, 'component'], null);
 
-      // component?
+      // If value was set to something from codebook, reset this flag
+      if (has(existingVariables, value)) {
+        changeField(form, '_createNewVariable', null);
+      }
       changeField(form, 'component', component);
       changeField(form, 'options', options);
       changeField(form, 'validation', validation);
+    },
+  handleNewVariable: ({ changeField, form }) =>
+    (value) => {
+      changeField(form, '_createNewVariable', value);
+      return value;
     },
 });
 
@@ -91,7 +106,6 @@ export {
 };
 
 export default compose(
-  withCreateVariableHandler,
   fieldsState,
   fieldsHandlers,
 );

--- a/src/ducks/modules/protocol/__tests__/__snapshots__/codebook.test.js.snap
+++ b/src/ducks/modules/protocol/__tests__/__snapshots__/codebook.test.js.snap
@@ -16,6 +16,7 @@ Object {
   "configuration": Object {
     "fizz": "buzz",
     "name": "bar",
+    "type": "text",
   },
   "meta": Object {
     "entity": "ego",
@@ -31,6 +32,7 @@ Object {
   "configuration": Object {
     "fizz": "buzz",
     "name": "bar",
+    "type": "text",
   },
   "meta": Object {
     "entity": "node",

--- a/src/ducks/modules/protocol/__tests__/codebook.test.js
+++ b/src/ducks/modules/protocol/__tests__/codebook.test.js
@@ -185,13 +185,26 @@ describe('protocol.codebook', () => {
         }).toThrow(new Error('Cannot create a new variable without a name'));
       });
 
+      it('It will not create a variable with no type', () => {
+        const createAction = actionCreators.createVariable(
+          'node',
+          'bar',
+          { foo: 'bar', name: 'bazz' },
+        );
+        const store = mockStore(testState);
+
+        expect(() => {
+          store.dispatch(createAction);
+        }).toThrow(new Error('Cannot create a new variable without a type'));
+      });
+
       it('dispatches the CREATE_VARIABLE action with a variable id for node', () => {
         const store = mockStore(testState);
 
         store.dispatch(actionCreators.createVariable(
           'node',
           'foo',
-          { fizz: 'buzz', name: 'bar' },
+          { fizz: 'buzz', name: 'bar', type: 'text' },
         ));
 
         const actions = store.getActions();
@@ -205,7 +218,7 @@ describe('protocol.codebook', () => {
         store.dispatch(actionCreators.createVariable(
           'ego',
           undefined,
-          { fizz: 'buzz', name: 'bar' },
+          { fizz: 'buzz', name: 'bar', type: 'text' },
         ));
 
         const actions = store.getActions();
@@ -214,7 +227,7 @@ describe('protocol.codebook', () => {
       });
 
       it('throws an error if a variable with the same name already exists', () => {
-        const createAction = actionCreators.createVariable('node', 'bar', { name: 'ALPHA' });
+        const createAction = actionCreators.createVariable('node', 'bar', { name: 'ALPHA', type: 'text' });
         const store = mockStore(testState);
 
         expect(() => {

--- a/src/ducks/modules/protocol/codebook.js
+++ b/src/ducks/modules/protocol/codebook.js
@@ -117,6 +117,10 @@ const createVariableThunk = (entity, type, configuration) =>
       throw new Error('Cannot create a new variable without a name');
     }
 
+    if (!configuration.type) {
+      throw new Error('Cannot create a new variable without a type');
+    }
+
     const safeConfiguration = {
       ...configuration,
       name: safeName(configuration.name),


### PR DESCRIPTION
For `sections/Form`:

- Temporarily store new variable name in form state
- Create the variable when the field is saved
- Update codebook module to require variable type

Resolves #539