### PR TITLE
Fix sociogram prompt editing

### DIFF
--- a/src/components/EditableList/withEditHandlers.js
+++ b/src/components/EditableList/withEditHandlers.js
@@ -35,11 +35,10 @@ const mapDispatchToProps = (dispatch, { form }) => ({
 });
 
 const mapItemStateToProps = (state, { form, itemSelector, editField, template }) => {
-  const item = formValueSelector(form)(state, editField);
+  const item = itemSelector(state, { form, editField });
+  const initialValues = item || { ...template(), id: uuid() };
 
-  if (!item) { return { initialValues: { ...template(), id: uuid() } }; }
-
-  return { initialValues: itemSelector(state, item) };
+  return { initialValues };
 };
 
 const stateHandlers = withStateHandlers(

--- a/src/components/sections/CategoricalBinPrompts/helpers.js
+++ b/src/components/sections/CategoricalBinPrompts/helpers.js
@@ -1,9 +1,14 @@
 /* eslint-disable import/prefer-default-export */
 
+import { formValueSelector } from 'redux-form';
 import { getOptionsForVariable } from '../../../selectors/codebook';
 
 export const itemSelector = (entity, type) =>
-  (state, prompt) => {
+  (state, { form, editField }) => {
+    const prompt = formValueSelector(form)(state, editField);
+
+    if (!prompt) { return null; }
+
     const variableOptions = getOptionsForVariable(
       state,
       { entity, type, variable: prompt.variable },

--- a/src/components/sections/Form/helpers.js
+++ b/src/components/sections/Form/helpers.js
@@ -1,4 +1,5 @@
 
+import { formValueSelector } from 'redux-form';
 import { omit, get, reduce } from 'lodash';
 import { getVariablesForSubject } from '../../../selectors/codebook';
 
@@ -23,15 +24,19 @@ export const normalizeField = field =>
 
 // Merge item with variable info from codebook
 export const itemSelector = (entity, type) =>
-  (state, prompt) => {
-    const variable = prompt.variable;
+  (state, { form, editField }) => {
+    const item = formValueSelector(form)(state, editField);
+
+    if (!item) { return null; }
+
+    const variable = item && item.variable;
 
     const codebookVariables = getVariablesForSubject(state, { entity, type });
     const codebookVariable = get(codebookVariables, variable, {});
     const codebookProperties = getCodebookProperties(codebookVariable);
 
     return {
-      ...prompt,
+      ...item,
       ...codebookProperties,
     };
   };


### PR DESCRIPTION
This PR fixes sociogram prompt editing, which was broken here: https://github.com/codaco/Architect/pull/575/commits/46beb43e29a376306274a4dfdf5f4740985e3c30

Fix is to revert some changes and instate a simpler fix for the ordinal bin issue. 

When reviewing, please verify that both ordinal/categorical bin prompt editing, and sociogram prompt editing work. Also verify that creating new prompts for each of these interfaces works, and does not cause protocol errors when saving.