### PR TITLE
Implement stage level node filtering

### DIFF
--- a/src/__mocks__/config.js
+++ b/src/__mocks__/config.js
@@ -1,3 +1,3 @@
-/* eslint-env jest */
+/* eslint-disable import/prefer-default-export */
 
 export const APP_SCHEMA_VERSION = '1';

--- a/src/components/StageEditor/Interfaces/AlterEdgeForm.js
+++ b/src/components/StageEditor/Interfaces/AlterEdgeForm.js
@@ -1,6 +1,7 @@
 import {
   Name,
   EdgeType,
+  Filter,
   Form,
   IntroductionPanel,
 } from '../../sections';
@@ -12,6 +13,7 @@ const AlterEdgeForm = {
   sections: [
     Name,
     EdgeType,
+    Filter,
     IntroductionPanel,
     Form,
   ],

--- a/src/components/StageEditor/Interfaces/AlterForm.js
+++ b/src/components/StageEditor/Interfaces/AlterForm.js
@@ -1,6 +1,7 @@
 import {
   Name,
   NodeType,
+  Filter,
   Form,
   IntroductionPanel,
 } from '../../sections';
@@ -9,6 +10,7 @@ const AlterForm = {
   sections: [
     Name,
     NodeType,
+    Filter,
     IntroductionPanel,
     Form,
   ],

--- a/src/components/StageEditor/Interfaces/CategoricalBin.js
+++ b/src/components/StageEditor/Interfaces/CategoricalBin.js
@@ -1,6 +1,7 @@
 import {
   Name,
   NodeType,
+  Filter,
   CategoricalBinPrompts,
 } from '../../sections';
 
@@ -8,6 +9,7 @@ const CategoricalBin = {
   sections: [
     Name,
     NodeType,
+    Filter,
     CategoricalBinPrompts,
   ],
 };

--- a/src/components/StageEditor/Interfaces/OrdinalBin.js
+++ b/src/components/StageEditor/Interfaces/OrdinalBin.js
@@ -1,6 +1,7 @@
 import {
   Name,
   NodeType,
+  Filter,
   OrdinalBinPrompts,
 } from '../../sections';
 
@@ -8,6 +9,7 @@ const OrdinalBin = {
   sections: [
     Name,
     NodeType,
+    Filter,
     OrdinalBinPrompts,
   ],
 };

--- a/src/components/StageEditor/Interfaces/Sociogram.js
+++ b/src/components/StageEditor/Interfaces/Sociogram.js
@@ -2,6 +2,7 @@ import {
   Name,
   Background,
   NodeType,
+  Filter,
   SociogramPrompts,
 } from '../../sections';
 
@@ -9,6 +10,7 @@ const Sociogram = {
   sections: [
     Name,
     NodeType,
+    Filter,
     Background,
     SociogramPrompts,
   ],

--- a/src/components/sections/Filter.js
+++ b/src/components/sections/Filter.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Field } from 'redux-form';
+import { getFieldId } from '../../utils/issues';
+import { Filter as FilterQuery, withFieldConnector, withStoreConnector } from '../Query';
+import Section from './Section';
+
+const FilterField = withFieldConnector(withStoreConnector(FilterQuery));
+
+const Filter = () => (
+  <Section contentId="guidance.editor.filter">
+    <div id={getFieldId('filter')} data-name="Filter text" />
+    <h2>Filter <small>(optional)</small></h2>
+    <p>
+      You can optionally filter which nodes are shown on this stage, by creating
+      one or more rules using the options below.
+    </p>
+    <Field
+      name="filter"
+      component={FilterField}
+    />
+  </Section>
+);
+
+export default Filter;

--- a/src/components/sections/index.js
+++ b/src/components/sections/index.js
@@ -6,6 +6,7 @@ export { default as SearchOptionsForExternalData } from './SearchOptionsForExter
 export { default as SortOptionsForExternalData } from './SortOptionsForExternalData';
 export { default as QuickAdd } from './QuickAdd';
 export { default as Title } from './Title';
+export { default as Filter } from './Filter';
 export { default as Name } from './Name';
 export { default as ShowExistingNodes } from './ShowExistingNodes';
 export { default as NodeType } from './NodeType';

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,7 @@ export const COLOR_PALETTE_BY_ENTITY = {
   edge: 'edge-color-seq',
 };
 
-// Target protocol schema version. Used to determine compatibility & migration 
+// Target protocol schema version. Used to determine compatibility & migration
 export const APP_SCHEMA_VERSION = '2';
 
 // Maps for supported asset types within the app. Used by asset chooser.


### PR DESCRIPTION
This PR implements stage level node filtering for the following interfaces:

- Ordinal bin
- Categorical bin
- Alter Form
- Alter Edge Form
- Sociogram

It is built off of the schema 2 support in feature/skip-logic-ordinal-categorical-vars