### PR TITLE
Use APP_SCHEMA_VERSION constant when creating new protocols

### DIFF
--- a/public/template/protocol.json
+++ b/public/template/protocol.json
@@ -4,6 +4,5 @@
     "edge": {},
     "ego": {}
   },
-  "assetManifest": {},
-  "schemaVersion": 4
+  "assetManifest": {}
 }

--- a/src/other/protocols/createProtocol.js
+++ b/src/other/protocols/createProtocol.js
@@ -1,6 +1,7 @@
 import { remote } from 'electron';
 import fse from 'fs-extra';
 import path from 'path';
+import { APP_SCHEMA_VERSION } from '@app/config';
 import getLocalDirectoryFromArchivePath from './lib/getLocalDirectoryFromArchivePath';
 
 const saveDialogOptions = {
@@ -30,6 +31,20 @@ const createProtocolWorkingPath = destinationPath =>
     const appPath = remote.app.getAppPath();
     const templatePath = path.join(appPath, 'template');
     fse.copySync(templatePath, destinationPath);
+
+    const protocolTemplate = fse.readJsonSync(
+      path.join(templatePath, 'protocol.json'),
+    );
+
+    const protocol = {
+      schemaVersion: APP_SCHEMA_VERSION,
+      ...protocolTemplate,
+    };
+
+    fse.writeJsonSync(
+      path.join(destinationPath, 'protocol.json'),
+      protocol,
+    );
 
     // TODO: update protocol with version number
 


### PR DESCRIPTION
Fixes app to use the APP_SCHEMA_VERSION to define the schema version of new protocols (and not just which protocols the app can open).

Resolves #612