### PR TITLE
Fix crashes when importing assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3048,15 +3048,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "attr-accept": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
-            "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.5.0"
-            }
-        },
         "author-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
@@ -9428,15 +9419,6 @@
             "requires": {
                 "loader-utils": "^1.0.2",
                 "schema-utils": "^0.4.5"
-            }
-        },
-        "file-selector": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.12.tgz",
-            "integrity": "sha512-Kx7RTzxyQipHuiqyZGf+Nz4vY9R1XGxuQl/hLoJwq+J4avk/9wxxgZyHKtbyIPJmbD4A66DWGYfyykWNpcYutQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
             }
         },
         "file-type": {
@@ -23417,16 +23399,6 @@
                 "reflect.ownkeys": "^0.2.0"
             }
         },
-        "prop-types-extra": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
-            "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
-            "dev": true,
-            "requires": {
-                "react-is": "^16.3.2",
-                "warning": "^3.0.0"
-            }
-        },
         "proxy-addr": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -24423,18 +24395,6 @@
             "dev": true,
             "requires": {
                 "classnames": "^2.2.5"
-            }
-        },
-        "react-dropzone": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-8.2.0.tgz",
-            "integrity": "sha512-G25lAPDn5QSEUUCgAsUyKqaqa/pV2B39jAdRl5bjl89DyOpK7uFPnF1GDY5io7wUj0Bn8txj44qU8Xglp8CHcw==",
-            "dev": true,
-            "requires": {
-                "attr-accept": "^1.1.3",
-                "file-selector": "^0.1.8",
-                "prop-types": "^15.6.2",
-                "prop-types-extra": "^1.1.0"
             }
         },
         "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
         "react-dev-utils": "9.1.0",
         "react-dom": "16.11.0",
         "react-draggable": "^2.2.3",
-        "react-dropzone": "^8.0.4",
         "react-error-overlay": "^5.0.4",
         "react-fastclick": "^3.0.2",
         "react-flip-toolkit": "^6.5.4",

--- a/src/components/AssetBrowser/AssetBrowser.js
+++ b/src/components/AssetBrowser/AssetBrowser.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 import Assets from './Assets';
@@ -10,27 +10,35 @@ const AssetBrowser = ({
   selected,
   onSelect,
   onDelete,
-}) => (
-  <div className="asset-browser">
-    <div className="asset-browser__content">
-      <div className="asset-browser__create">
-        <NewAsset
-          onCreate={onSelect}
-          type={type}
-        />
-      </div>
-      <div className="asset-browser__assets">
-        <h3>Choose asset from library</h3>
-        <Assets
-          onSelect={onSelect}
-          onDelete={onDelete}
-          selected={selected}
-          type={type}
-        />
+}) => {
+  const handleCreate = useCallback((assetIds) => {
+    if (assetIds.length !== 1) { return; } // if multiple files were uploaded
+    if (!assetIds[0]) { return; } // if a single invalid file was uploaded
+    onSelect(assetIds[0]);
+  }, [onSelect]);
+
+  return (
+    <div className="asset-browser">
+      <div className="asset-browser__content">
+        <div className="asset-browser__create">
+          <NewAsset
+            onCreate={handleCreate}
+            type={type}
+          />
+        </div>
+        <div className="asset-browser__assets">
+          <h3>Choose asset from library</h3>
+          <Assets
+            onSelect={onSelect}
+            onDelete={onDelete}
+            selected={selected}
+            type={type}
+          />
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+}
 
 AssetBrowser.propTypes = {
   type: PropTypes.string,

--- a/src/components/AssetBrowser/AssetBrowser.js
+++ b/src/components/AssetBrowser/AssetBrowser.js
@@ -38,7 +38,7 @@ const AssetBrowser = ({
       </div>
     </div>
   );
-}
+};
 
 AssetBrowser.propTypes = {
   type: PropTypes.string,

--- a/src/components/AssetBrowser/NewAsset.js
+++ b/src/components/AssetBrowser/NewAsset.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import AutoFileDrop from '../Form/AutoFileDrop';
 
@@ -7,27 +7,18 @@ import AutoFileDrop from '../Form/AutoFileDrop';
  *
  * Value should be assetId
  */
-class NewAsset extends Component {
-  handleDrop = (assetId) => {
-    this.props.onCreate(assetId);
-  }
-
-  render() {
-    const {
-      type,
-    } = this.props;
-
-    return (
-      <div className="asset-browser-new-asset">
-        <h3>Create new asset</h3>
-        <AutoFileDrop
-          type={type}
-          onDrop={this.handleDrop}
-        />
-      </div>
-    );
-  }
-}
+const NewAsset = ({
+  type,
+  onCreate,
+}) => (
+  <div className="asset-browser-new-asset">
+    <h3>Create new asset</h3>
+    <AutoFileDrop
+      type={type}
+      onDrop={onCreate}
+    />
+  </div>
+);
 
 NewAsset.propTypes = {
   type: PropTypes.string,

--- a/src/components/Form/AutoFileDrop.js
+++ b/src/components/Form/AutoFileDrop.js
@@ -2,9 +2,9 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { has } from 'lodash';
 import { compose, withProps, withHandlers } from 'recompose';
+import { SUPPORTED_EXTENSION_TYPE_MAP } from '@app/config';
+import { actionCreators as assetActions } from '@modules/protocol/assetManifest';
 import Dropzone from './Dropzone';
-import { SUPPORTED_EXTENSION_TYPE_MAP } from '../../config';
-import { actionCreators as assetActions } from '../../ducks/modules/protocol/assetManifest';
 
 const mapDispatchToProps = dispatch => ({
   importAsset: bindActionCreators(assetActions.importAsset, dispatch),

--- a/src/components/Form/AutoFileDrop.js
+++ b/src/components/Form/AutoFileDrop.js
@@ -31,14 +31,15 @@ const autoFileDrop = compose(
   connect(null, mapDispatchToProps),
   withHandlers({
     onDrop: ({ importAsset, onDrop }) =>
-      (acceptedFiles) => {
-        acceptedFiles.forEach((file) => {
-          importAsset(file)
-            .then(({ id }) => {
-              onDrop(id);
-            });
-        });
-      },
+      filePaths =>
+        Promise.all(
+          filePaths.map(
+            filePath =>
+              importAsset(filePath)
+                .then(({ id }) => id),
+          ),
+        )
+          .then(ids => onDrop(ids)),
   }),
 );
 

--- a/src/components/Form/AutoFileDrop.js
+++ b/src/components/Form/AutoFileDrop.js
@@ -1,9 +1,9 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { has, each } from 'lodash';
+import { has } from 'lodash';
 import { compose, withProps, withHandlers } from 'recompose';
 import Dropzone from './Dropzone';
-import { SUPPORTED_MIME_TYPE_MAP, SUPPORTED_EXTENSION_TYPE_MAP } from '../../config';
+import { SUPPORTED_EXTENSION_TYPE_MAP } from '../../config';
 import { actionCreators as assetActions } from '../../ducks/modules/protocol/assetManifest';
 
 const mapDispatchToProps = dispatch => ({
@@ -14,16 +14,12 @@ const autoFileDrop = compose(
   withProps(({ type }) => {
     // Handle no 'type' required - still enforce only allowing supported file types
     if (!type || !has(SUPPORTED_EXTENSION_TYPE_MAP, type)) {
-      const consolidatedList = [];
-      each(SUPPORTED_EXTENSION_TYPE_MAP, (value, key) => {
-        consolidatedList.push(...value, ...SUPPORTED_MIME_TYPE_MAP[key]);
-      });
+      const consolidatedList = [].concat(...Object.values(SUPPORTED_EXTENSION_TYPE_MAP));
       return { accepts: consolidatedList };
     }
 
     return {
       accepts: [
-        ...SUPPORTED_MIME_TYPE_MAP[type],
         ...SUPPORTED_EXTENSION_TYPE_MAP[type],
       ],
     };

--- a/src/components/Form/Dropzone.js
+++ b/src/components/Form/Dropzone.js
@@ -1,47 +1,143 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import cx from 'classnames';
-import ReactDropzone from 'react-dropzone';
+import { times } from 'lodash';
+
+const { dialog } = require('electron').remote;
+
+const matchExtension = (path, extension) =>
+  RegExp(`${extension}$`).test(path);
+
+const acceptsPath = accepts => path =>
+  accepts.some(accept => matchExtension(path, accept));
+
+const acceptsPaths = (accepts, paths) => {
+  if (!paths || paths.length === 0) { return false; }
+  return paths.every(acceptsPath(accepts));
+};
+
+const getAcceptsExtensions = accepts =>
+  accepts
+    .filter(accept => /^\.[a-z]+$/.test(accept))
+    .map(accept => accept.substr(1));
+
+const initialState = {
+  isActive: false, // is doing something
+  isAcceptable: false, // can accept file
+  isDisabled: false, // is disabled
+  error: null,
+};
 
 const Dropzone = ({
   onDrop,
+  className,
   accepts,
-}) => (
-  <ReactDropzone
-    onDrop={onDrop}
-    multiple={false}
-    accept={accepts}
-  >
-    {
-      ({
-        getRootProps,
-        getInputProps,
-        isDragActive,
-        isDragAccept,
-        isDragReject,
-        isDragDisabled,
-      }) => (
-        <div
-          {...getRootProps()}
-          className={cx(
-            'form-dropzone',
-            {
-              'form-dropzone--active': isDragActive,
-              'form-dropzone--accept': isDragAccept,
-              'form-dropzone--reject': isDragReject,
-              'form-dropzone--disabled': isDragDisabled,
-            },
-          )}
-        >
-          <div className="form-dropzone__container" />
-          <div className="form-dropzone__label">
-            Drop a file here or&nbsp;<div className="form-dropzone__link">click to browse</div>
-          </div>
-          <input {...getInputProps()} />
-        </div>
-      )
+  disabled,
+}) => {
+  const [state, setState] = useState(initialState);
+
+  const acceptsKey = accepts.toString();
+  const isDisabled = disabled || state.isActive;
+
+  const startHandler = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (isDisabled) { return false; }
+
+    setState(previousState => ({ ...previousState, isActive: true }));
+
+    return true;
+  };
+
+  const submitPaths = (filePaths) => {
+    const isAcceptable = acceptsPaths(accepts, filePaths);
+
+    if (!isAcceptable) {
+      setState(previousState => ({ ...previousState, isActive: false }));
+      return;
     }
-  </ReactDropzone>
-);
+
+    setState(previousState => ({ ...previousState, isAcceptable: true }));
+
+    onDrop(filePaths)
+      .finally(() => {
+        setState(previousState => ({ ...previousState, ...initialState }));
+      });
+  };
+
+  const handleClick = useCallback((e) => {
+    if (!startHandler(e)) { return; }
+
+    const extensions = getAcceptsExtensions(accepts);
+
+    dialog.showOpenDialog({
+      filters: [
+        // TODO: name!
+        { name: 'Images', extensions },
+      ],
+    }, filePaths => submitPaths(filePaths));
+  }, [acceptsKey, isDisabled, submitPaths]);
+
+  const handleDrop = useCallback((e) => {
+    if (!startHandler(e)) { return; }
+
+    const files = e.dataTransfer.files;
+    const filePaths = times(files.length, i => files.item(i).path);
+
+    // If the user drags a file attachment from a browser, we get a url instead of a file
+    if (!files || filePaths.length < 1) {
+      const urlName = e.dataTransfer.getData && e.dataTransfer.getData('URL');
+
+      if (urlName) {
+        const errorMessage = 'Dragging files from this source is not currently supported. Please download the file to your computer and try again.';
+        setState(previousState => ({ ...previousState, isActive: false, error: errorMessage }));
+        return;
+      }
+    }
+
+    submitPaths(filePaths);
+  }, [acceptsKey, isDisabled, submitPaths]);
+
+  const handleDragEnter = useCallback(() => {
+    if (isDisabled) { return; }
+    setState(previousState => ({ ...previousState, isHover: true }));
+  }, [isDisabled]);
+
+  const handleDragExit = useCallback(() => {
+    setState(previousState => ({ ...previousState, isHover: false }));
+  });
+
+  const dropzoneClasses = cx(
+    className,
+    {
+      [`${className}--active`]: true, //state.isActive,
+      [`${className}--hover`]: state.isHover,
+      [`${className}--disabled`]: isDisabled,
+      [`${className}--error`]: state.error,
+    },
+  );
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragEnter={handleDragEnter}
+      onDragExit={handleDragExit}
+    >
+      <div className={dropzoneClasses}>
+        <div className={`${className}__container`} />
+        <div className={`${className}__label`}>
+          Drop a file here or&nbsp;
+          <div className={`${className}__link`} onClick={handleClick}>click to browse</div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+Dropzone.defaultProps = {
+  className: 'form-dropzone',
+};
 
 export { Dropzone };
 

--- a/src/components/Form/Dropzone.js
+++ b/src/components/Form/Dropzone.js
@@ -75,8 +75,7 @@ const Dropzone = ({
 
     dialog.showOpenDialog({
       filters: [
-        // TODO: name!
-        { name: 'Images', extensions },
+        { name: 'Asset', extensions },
       ],
     }, filePaths => submitPaths(filePaths));
   }, [acceptsKey, isDisabled, submitPaths]);

--- a/src/components/Form/Dropzone.js
+++ b/src/components/Form/Dropzone.js
@@ -18,9 +18,7 @@ const acceptsPaths = (accepts, paths) => {
 };
 
 const getAcceptsExtensions = accepts =>
-  accepts
-    .filter(accept => /^\.[a-z]+$/.test(accept))
-    .map(accept => accept.substr(1));
+  accepts.map(accept => accept.substr(1));
 
 const initialState = {
   isActive: false, // is doing something

--- a/src/components/Form/Dropzone.js
+++ b/src/components/Form/Dropzone.js
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { times } from 'lodash';
 import { Spinner } from '@codaco/ui';
@@ -61,12 +62,10 @@ const Dropzone = ({
 
     setState(previousState => ({ ...previousState, isAcceptable: true, isLoading: true }));
 
-    setTimeout(() => {
-      onDrop(filePaths)
-        .finally(() => {
-          setState(previousState => ({ ...previousState, ...initialState }));
-        });
-    }, 3000);
+    onDrop(filePaths)
+      .finally(() => {
+        setState(previousState => ({ ...previousState, ...initialState }));
+      });
   };
 
   const handleClick = useCallback((e) => {
@@ -144,6 +143,15 @@ const Dropzone = ({
 
 Dropzone.defaultProps = {
   className: 'form-dropzone',
+  accepts: [],
+  disabled: false,
+};
+
+Dropzone.propTypes = {
+  onDrop: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  accepts: PropTypes.array,
+  disabled: PropTypes.bool,
 };
 
 export { Dropzone };

--- a/src/components/Form/Dropzone.js
+++ b/src/components/Form/Dropzone.js
@@ -7,13 +7,13 @@ import { Spinner, Icon } from '@codaco/ui';
 const { dialog } = require('electron').remote;
 
 const getExtension = (path) => {
-  const match = /(.[a-z0-9]+)$/.exec(path);
+  const match = /(.[A-Za-z0-9]+)$/.exec(path);
   if (!match) { return null; }
   return match[1];
 };
 
 const matchExtension = (path, extension) =>
-  RegExp(`${extension}$`).test(path);
+  RegExp(`${extension}$`).test(path.toLowerCase());
 
 const acceptsPath = accepts => path =>
   accepts.some(accept => matchExtension(path, accept));

--- a/src/components/Form/Dropzone.js
+++ b/src/components/Form/Dropzone.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import cx from 'classnames';
 import { times } from 'lodash';
+import { Spinner } from '@codaco/ui';
 
 const { dialog } = require('electron').remote;
 
@@ -24,6 +25,7 @@ const initialState = {
   isActive: false, // is doing something
   isAcceptable: false, // can accept file
   isDisabled: false, // is disabled
+  isLoading: false, // file is being imported
   error: null,
 };
 
@@ -57,12 +59,14 @@ const Dropzone = ({
       return;
     }
 
-    setState(previousState => ({ ...previousState, isAcceptable: true }));
+    setState(previousState => ({ ...previousState, isAcceptable: true, isLoading: true }));
 
-    onDrop(filePaths)
-      .finally(() => {
-        setState(previousState => ({ ...previousState, ...initialState }));
-      });
+    setTimeout(() => {
+      onDrop(filePaths)
+        .finally(() => {
+          setState(previousState => ({ ...previousState, ...initialState }));
+        });
+    }, 3000);
   };
 
   const handleClick = useCallback((e) => {
@@ -110,8 +114,9 @@ const Dropzone = ({
   const dropzoneClasses = cx(
     className,
     {
-      [`${className}--active`]: true, //state.isActive,
+      [`${className}--active`]: state.isActive,
       [`${className}--hover`]: state.isHover,
+      [`${className}--loading`]: state.isLoading,
       [`${className}--disabled`]: isDisabled,
       [`${className}--error`]: state.error,
     },
@@ -123,13 +128,15 @@ const Dropzone = ({
       onDragEnter={handleDragEnter}
       onDragExit={handleDragExit}
     >
-      <div className={dropzoneClasses}>
+      <div className={dropzoneClasses} onClick={handleClick}>
         <div className={`${className}__container`} />
         <div className={`${className}__label`}>
           Drop a file here or&nbsp;
-          <div className={`${className}__link`} onClick={handleClick}>click to browse</div>
+          <div className={`${className}__link`}>click to browse</div>
         </div>
-
+        <div className={`${className}__loading`}>
+          { state.isActive && <Spinner small /> }
+        </div>
       </div>
     </div>
   );

--- a/src/components/Form/Dropzone/__tests__/helpers.test.js
+++ b/src/components/Form/Dropzone/__tests__/helpers.test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+
+import { SUPPORTED_EXTENSION_TYPE_MAP } from '@app/config';
+import { acceptsPaths, getRejectedExtensions, getAcceptsExtensions } from '../helpers';
+
+// acceptsPaths = (accepts, paths) =>
+// getRejectedExtensions = (accepts, paths) =>
+// getAcceptsExtensions = accepts =>
+
+describe('acceptsPaths(accepts, paths)', () => {
+  it('given a list of file extensions, and a list of paths it checks all paths are valid', () => {
+    const accepts = ['.foo', '.baz4', '.b3uzz'];
+    const passingPaths = ['/tmp/file.foo', '/tmp/file.baz4', '/tmp/file.b3uzz'];
+    const mixedCasePaths = ['/tmp/file.FOO', '/tmp/file.bAZ4'];
+    const failingPaths = ['/tmp/file.foo', '/tmp/file.fizz'];
+
+    expect(acceptsPaths(accepts, passingPaths)).toBe(true);
+    expect(acceptsPaths(accepts, mixedCasePaths)).toBe(true);
+    expect(acceptsPaths(accepts, failingPaths)).toBe(false);
+  });
+});
+
+describe('getRejectedExtensions(accepts, paths)', () => {
+  it('given a list of file extensions, and a list of paths it returns those that do not match', () => {
+    const accepts = ['.foo', '.bar', '.baz4', '.b3uzz'];
+    const passingPaths = ['/tmp/file.foo', '/tmp/file.bar', '/tmp/file.baz4', '/tmp/file.b3uzz'];
+    const failingPaths = ['/tmp/file.foo', '/tmp/file.FIZZ', '/tmp/file.pop'];
+
+    expect(getRejectedExtensions(accepts, passingPaths)).toEqual([]);
+    expect(getRejectedExtensions(accepts, failingPaths)).toEqual(['.FIZZ', '.pop']);
+  });
+});
+
+describe('getAcceptsExtensions(accepts)', () => {
+  it('given a list of file extensions, it returns them without the "." (for the electron open file dialog)', () => {
+    const accepts = ['.foo', '.bar', '.baz4', '.b3uzz'];
+
+    expect(getAcceptsExtensions(accepts)).toEqual(['foo', 'bar', 'baz4', 'b3uzz']);
+  });
+});

--- a/src/components/Form/Dropzone/__tests__/helpers.test.js
+++ b/src/components/Form/Dropzone/__tests__/helpers.test.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import { SUPPORTED_EXTENSION_TYPE_MAP } from '@app/config';
 import { acceptsPaths, getRejectedExtensions, getAcceptsExtensions } from '../helpers';
 
 // acceptsPaths = (accepts, paths) =>

--- a/src/components/Form/Dropzone/helpers.js
+++ b/src/components/Form/Dropzone/helpers.js
@@ -1,0 +1,28 @@
+
+const getExtension = (path) => {
+  const match = /(.[A-Za-z0-9]+)$/.exec(path);
+  if (!match) { return null; }
+  return match[1];
+};
+
+const matchExtension = (path, extension) =>
+  RegExp(`${extension}$`).test(path.toLowerCase());
+
+const acceptsPath = accepts => path =>
+  accepts.some(accept => matchExtension(path, accept));
+
+export const acceptsPaths = (accepts, paths) => {
+  if (!paths || paths.length === 0) { return false; }
+  return paths.every(acceptsPath(accepts));
+};
+
+export const getRejectedExtensions = (accepts, paths) =>
+  paths.reduce((memo, path) => {
+    if (acceptsPath(accepts)(path)) { return memo; }
+    const extension = getExtension(path);
+    if (memo.includes(extension)) { return memo; }
+    return [...memo, extension];
+  }, []);
+
+export const getAcceptsExtensions = accepts =>
+  accepts.map(accept => accept.substr(1));

--- a/src/components/Form/Dropzone/useTimer.js
+++ b/src/components/Form/Dropzone/useTimer.js
@@ -1,0 +1,19 @@
+import { useRef } from 'react';
+
+const useTimer = () => {
+  const timer = useRef();
+
+  const clearTimer = () => {
+    if (!timer.current) { return; }
+    clearTimeout(timer.current);
+  };
+
+  const setTimer = (callback, delay) => {
+    clearTimer();
+    timer.current = setTimeout(callback, delay);
+  };
+
+  return setTimer;
+};
+
+export default useTimer;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -26,6 +26,6 @@ export const APP_SCHEMA_VERSION = 4;
 export const SUPPORTED_EXTENSION_TYPE_MAP = {
   network: ['.csv', '.json'],
   image: ['.jpg', '.jpeg', '.gif', '.png'],
-  audio: ['.mp3', '.aiff'],
+  audio: ['.mp3', '.aiff', '.m4a'],
   video: ['.mov', '.mp4'],
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -26,6 +26,6 @@ export const APP_SCHEMA_VERSION = 4;
 export const SUPPORTED_EXTENSION_TYPE_MAP = {
   network: ['.csv', '.json'],
   image: ['.jpg', '.jpeg', '.gif', '.png'],
-  audio: ['.mp3', '.aiff', '.m4a'],
+  audio: ['.mp3', '.aiff', '.m4a', '.mp4'],
   video: ['.mov', '.mp4'],
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -23,14 +23,6 @@ export const COLOR_PALETTE_BY_ENTITY = {
 export const APP_SCHEMA_VERSION = 4;
 
 // Maps for supported asset types within the app. Used by asset chooser.
-// Remember to also update getNetworkType when changing these!
-export const SUPPORTED_MIME_TYPE_MAP = {
-  network: ['application/json', 'text/csv', 'application/vnd.ms-excel'],
-  image: ['image/*'],
-  audio: ['audio/*'],
-  video: ['video/*'],
-};
-
 export const SUPPORTED_EXTENSION_TYPE_MAP = {
   network: ['.csv', '.json'],
   image: ['.jpg', '.jpeg', '.gif', '.png'],

--- a/src/ducks/modules/protocol/__tests__/assetManifest.test.js
+++ b/src/ducks/modules/protocol/__tests__/assetManifest.test.js
@@ -38,11 +38,10 @@ describe('protocol/assetManifest', () => {
   });
 
   describe('importAsset()', () => {
-    const file = new File(
-      ['image/data'],
-      'bazz.jpg',
-      { type: 'image/jpeg' },
-    );
+    const file = {
+      text: Promise.resolve('image/data'),
+      name: 'bazz.jpg',
+    };
 
     beforeEach(() => {
       importAsset.mockClear();
@@ -51,11 +50,11 @@ describe('protocol/assetManifest', () => {
     it('calls importAsset and fires complete action', () => {
       const store = getStore();
 
-      return store.dispatch(actionCreators.importAsset(file))
+      return store.dispatch(actionCreators.importAsset(file.name))
         .then(() => {
           expect(log.mock.calls[0][0].type).toEqual(actionTypes.IMPORT_ASSET);
           expect(log.mock.calls[1][0].type).toEqual(actionTypes.IMPORT_ASSET_COMPLETE);
-          expect(importAsset.mock.calls).toEqual([['/tmp/foo/bar', file]]);
+          expect(importAsset.mock.calls).toEqual([['/tmp/foo/bar', file.name]]);
         });
     });
 
@@ -67,10 +66,10 @@ describe('protocol/assetManifest', () => {
 
       const store = getStore();
 
-      return store.dispatch(actionCreators.importAsset(file)).then(() => {
+      return store.dispatch(actionCreators.importAsset(file.name)).then(() => {
         expect(log.mock.calls[0][0].type).toEqual(actionTypes.IMPORT_ASSET);
         expect(log.mock.calls[2][0].type).toEqual(actionTypes.IMPORT_ASSET_FAILED);
-        expect(importAsset.mock.calls).toEqual([['/tmp/foo/bar', file]]);
+        expect(importAsset.mock.calls).toEqual([['/tmp/foo/bar', file.name]]);
       });
     });
   });

--- a/src/ducks/modules/protocol/assetManifest.js
+++ b/src/ducks/modules/protocol/assetManifest.js
@@ -54,34 +54,34 @@ const importAssetFailed = (filename, error) =>
   });
 
 /**
- * @param {File} asset - File() to import
+ * @param {File} filePath - File path to import
  */
-const importAssetThunk = asset =>
+const importAssetThunk = filePath =>
   (dispatch, getState) => {
     const state = getState();
     const { workingPath } = getActiveProtocolMeta(state);
-    const name = getNameFromFilename(asset.name);
+    const name = getNameFromFilename(filePath);
 
     dispatch(importAsset(name));
-    log.info('Import asset', asset.name);
+    log.info('Import asset', filePath);
 
     if (!workingPath) {
       const error = new Error('No working path found, possibly no active protocol.');
-      dispatch(importAssetFailed(asset.name, error));
-      dispatch(importAssetErrorDialog(error, asset.name));
+      dispatch(importAssetFailed(filePath, error));
+      dispatch(importAssetErrorDialog(error, filePath));
       return Promise.reject(error);
     }
 
-    return validateAsset(asset)
-      .then(() => fsImportAsset(workingPath, asset))
-      .then(({ filePath, assetType }) => {
+    return validateAsset(filePath)
+      .then(() => fsImportAsset(workingPath, filePath))
+      .then((result) => {
         log.info('  OK');
-        return dispatch(importAssetComplete(filePath, name, assetType));
+        return dispatch(importAssetComplete(result.filePath, name, result.assetType));
       })
       .catch((error) => {
         log.error('  ERROR', error);
-        dispatch(invalidAssetErrorDialog(error, asset.name));
-        return dispatch(importAssetFailed(asset.name, error));
+        dispatch(invalidAssetErrorDialog(error, filePath));
+        return dispatch(importAssetFailed(filePath, error));
       });
   };
 

--- a/src/styles/components/editable-list/_window.scss
+++ b/src/styles/components/editable-list/_window.scss
@@ -8,7 +8,6 @@
   color: var(--architect-text);
   display: flex;
   background-color: var(--modal-overlay);
-  z-index: 1000;
 
   @supports (backdrop-filter: blur(.75rem)) {
     background: var(--modal-overlay);

--- a/src/styles/components/form/_dropzone.scss
+++ b/src/styles/components/form/_dropzone.scss
@@ -6,7 +6,7 @@
   height: unit(12);
   border-width: 2px;
   border-style: solid;
-  transition-duration: var(--animation-duration-fast);
+  transition-duration: var(--animation-duration-slow);
   transition-timing-function: var(--animation-easing);
   transition-property: border-color;
   border-color: transparent;
@@ -64,11 +64,15 @@
 
   &--active {
     cursor: initial;
-    // border-color: var(--notice);
 
     .form-dropzone__label {
       opacity: .5;
     }
+  }
+
+  &--hover {
+    border-color: var(--notice);
+    transition-duration: var(--animation-duration-fast);
   }
 
   &--loading {
@@ -84,10 +88,32 @@
   }
 
   &--error {
-    border-color: var(--error);
+    border-color: var(--warning);
+    transition-duration: var(--animation-duration-fast);
+  }
 
-    .form-dropzone__container {
-      background-color: var(--error);
+  &__error {
+    margin-top: unit(1);
+    overflow: hidden;
+    padding: unit(1) unit(2);
+    border-radius: unit(1);
+    background-color: var(--warning);
+    opacity: 0;
+    transform-origin: top center;
+    transition-duration: var(--animation-duration-fast);
+    transition-property: opacity;
+    display: flex;
+    align-items: center;
+    // justify-content: flex-end;
+
+    .icon {
+      width: 1.25rem;
+      height: 1.25rem;
+      margin-right: .5rem;
+    }
+
+    &--show {
+      opacity: 1;
     }
   }
 }

--- a/src/styles/components/form/_dropzone.scss
+++ b/src/styles/components/form/_dropzone.scss
@@ -27,7 +27,7 @@
     background-color: transparent;
     transition-duration: var(--animation-duration-fast);
     transition-timing-function: var(--animation-easing);
-    transition-property: filter, background-color;
+    transition-property: background-color;
   }
 
   &__label {
@@ -36,7 +36,7 @@
     color: var(--color-white);
     transition-duration: var(--animation-duration-standard);
     transition-timing-function: var(--animation-easing);
-    transition-property: filter;
+    transition-property: opacity;
     line-height: unit(2);
   }
 
@@ -47,16 +47,47 @@
     cursor: pointer;
   }
 
-  &--accept {
-    // border-color: var(--notice);
+  &__loading {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    opacity: 0;
+    transition-duration: var(--animation-duration-standard);
+    transition-timing-function: var(--animation-easing);
+    transition-property: opacity;
   }
 
-  // &--reject {
-  //   border-color: var(--error);
+  &--active {
+    cursor: initial;
+    // border-color: var(--notice);
 
-  //   .form-dropzone__container {
-  //     background-color: var(--error);
-  //     filter: brightness(.3);
-  //   }
-  // }
+    .form-dropzone__label {
+      opacity: .5;
+    }
+  }
+
+  &--loading {
+    cursor: wait;
+
+    .form-dropzone__label {
+      opacity: 0;
+    }
+
+    .form-dropzone__loading {
+      opacity: 1;
+    }
+  }
+
+  &--error {
+    border-color: var(--error);
+
+    .form-dropzone__container {
+      background-color: var(--error);
+    }
+  }
 }

--- a/src/styles/components/form/_dropzone.scss
+++ b/src/styles/components/form/_dropzone.scss
@@ -48,15 +48,15 @@
   }
 
   &--accept {
-    border-color: var(--notice);
+    // border-color: var(--notice);
   }
 
-  &--reject {
-    border-color: var(--error);
+  // &--reject {
+  //   border-color: var(--error);
 
-    .form-dropzone__container {
-      background-color: var(--error);
-      filter: brightness(.3);
-    }
-  }
+  //   .form-dropzone__container {
+  //     background-color: var(--error);
+  //     filter: brightness(.3);
+  //   }
+  // }
 }


### PR DESCRIPTION
Architect was crashing intermittently when importing files (https://github.com/codaco/Architect/issues/615).

Stripped the implementation back to a plain `<input type="file" />`, and app was still crashing. 

Believe this to be due to the following reported issue in electron v5: https://github.com/electron/electron/issues/21025

As update is not feasible, this fix instead switches from an input to use uses Electron's `showOpenDialog` method (https://github.com/electron/electron/blob/5-0-x/docs/api/dialog.md), and native node `fs` to import the file.

Changes:
- Should be faster since we are now doing a `fs-extra` copy() rather than reading and writing the file in the JS render process.
- Included better error handling, distinguishing validation from import errors
- Added a 'loading' state to the asset handler.

Resolves #615 