### PR TITLE
Warn about duplicate variables in creatable select

### DIFF
--- a/src/components/Form/Fields/CreatableSelect.js
+++ b/src/components/Form/Fields/CreatableSelect.js
@@ -38,6 +38,13 @@ class CreatableSelect extends PureComponent {
     );
 
   handleChange = (option) => {
+    // We are presenting a "fake" option to show an error message,
+    // if it is selected we ignore the action.
+    // eslint-disable-next-line no-underscore-dangle
+    if (option.__isWarning__) {
+      return;
+    }
+
     if (option && option.value) {
       this.props.input.onChange(option.value);
     } else {
@@ -141,6 +148,7 @@ class CreatableSelect extends PureComponent {
 
             // True if option matches the label prop of the supplied object
             const matchLabel = ({ label: variableLabel }) =>
+              variableLabel && option &&
               variableLabel.toLowerCase() === option.toLowerCase();
             const alreadyExists = options.some(matchLabel);
             const isReserved = reserved.some(matchLabel);

--- a/src/components/Form/Fields/CreatableSelect.js
+++ b/src/components/Form/Fields/CreatableSelect.js
@@ -66,6 +66,7 @@ class CreatableSelect extends PureComponent {
       input: { onBlur, ...input },
       children,
       options,
+      reserved,
       selectOptionComponent: SelectOptionComponent,
       label,
       onCreateOption,
@@ -121,7 +122,9 @@ class CreatableSelect extends PureComponent {
             const matchLabel = ({ label: variableLabel }) => variableLabel === option;
             const alreadyExists = options.some(matchLabel);
 
-            return !isEmpty && !alreadyExists;
+            const isReserved = reserved.some(matchLabel);
+
+            return !isEmpty && !alreadyExists && !isReserved;
           }}
 
           {...rest}
@@ -143,6 +146,7 @@ CreatableSelect.propTypes = {
   onDeleteOption: PropTypes.func,
   label: PropTypes.string,
   children: PropTypes.node,
+  reserved: PropTypes.array,
   meta: PropTypes.object,
 };
 
@@ -154,6 +158,7 @@ CreatableSelect.defaultProps = {
   input: {},
   label: null,
   children: null,
+  reserved: [],
   meta: { invalid: false, error: null, touched: false },
 };
 

--- a/src/components/Form/Fields/DefaultSelectOption.js
+++ b/src/components/Form/Fields/DefaultSelectOption.js
@@ -9,7 +9,7 @@ const DefaultSelectOption = (props) => {
   /* eslint-disable no-underscore-dangle */
   const isWarning = !!data.__isWarning__;
   const showNew = !!data.__createNewOption__ || !!data.__isNew__;
-  const showDelete = !data.__isNew__ && !!props.onDeleteOption && !data.isUsed;
+  const showDelete = !isWarning && !data.__isNew__ && !!props.onDeleteOption && !data.isUsed;
   const label = data.__createNewOption__ ?
     data.__createNewOption__ :
     data.label;

--- a/src/components/Form/Fields/DefaultSelectOption.js
+++ b/src/components/Form/Fields/DefaultSelectOption.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { components as ReactSelectComponents } from 'react-select';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import Icon from '@codaco/ui/lib/components/Icon';
 
 const DefaultSelectOption = (props) => {
   const { data } = props;
   /* eslint-disable no-underscore-dangle */
+  const isWarning = !!data.__isWarning__;
   const showNew = !!data.__createNewOption__ || !!data.__isNew__;
   const showDelete = !data.__isNew__ && !!props.onDeleteOption && !data.isUsed;
   const label = data.__createNewOption__ ?
@@ -17,12 +19,22 @@ const DefaultSelectOption = (props) => {
   };
   /* eslint-enable */
 
+  const classes = cx(
+    'form-fields-select__item',
+    { 'form-fields-select__item--warning': isWarning },
+  );
+
   return (
     <ReactSelectComponents.Option
       {...props}
-      className="form-fields-select__item"
+      className={classes}
       classNamePrefix="form-fields-select__item"
     >
+      { isWarning &&
+        <div className="form-fields-select__item-warning">
+          <Icon name="warning" />
+        </div>
+      }
       { showNew &&
         <div className="form-fields-select__item-add">
           <Icon name="add" />

--- a/src/components/Form/Fields/VariableSelect.js
+++ b/src/components/Form/Fields/VariableSelect.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { getVariableOptionsForSubject } from '@selectors/codebook';
+import CreatableSelect from './CreatableSelect';
+
+const mapStateToProps = (state, { entity, type }) => {
+  const existingVariables = getVariableOptionsForSubject(state, { entity, type });
+
+  return { reserved: existingVariables };
+};
+
+// TODO: For now just map existing variables, but later could also append create handlers!
+const VariableSelect = ({ reserved, ...props }) => (
+  <CreatableSelect {...props} reserved={reserved} />
+);
+
+VariableSelect.propTypes = {
+  entity: PropTypes.string.isRequired,
+  reserved: PropTypes.array,
+  type: PropTypes.string.isRequired,
+};
+
+VariableSelect.defaultProps = {
+  reserved: [],
+};
+
+export default connect(mapStateToProps)(VariableSelect);

--- a/src/components/Form/Fields/index.js
+++ b/src/components/Form/Fields/index.js
@@ -1,15 +1,16 @@
 /* eslint-disable import/prefer-default-export */
-export { default as TextArea } from './TextArea';
-export { default as Select } from './Select';
+export { default as Audio } from './Audio';
+export { default as ColorPicker } from './ColorPicker';
+export { default as Contexts } from './Contexts';
 export { default as CreatableSelect } from './CreatableSelect';
-export { default as Markdown } from './Markdown';
+export { default as Date } from './Date';
 export { default as File } from './File';
 export { default as Image } from './Image';
-export { default as Audio } from './Audio';
-export { default as Video } from './Video';
-export { default as Contexts } from './Contexts';
+export { default as Markdown } from './Markdown';
 export { default as Mode } from './Mode';
-export { default as OrderBy } from './OrderBy';
 export { default as NodeSelect } from './NodeSelect';
-export { default as ColorPicker } from './ColorPicker';
-export { default as Date } from './Date';
+export { default as OrderBy } from './OrderBy';
+export { default as Select } from './Select';
+export { default as TextArea } from './TextArea';
+export { default as VariableSelect } from './VariableSelect';
+export { default as Video } from './Video';

--- a/src/components/InlineEditScreen/InlineEditScreen.js
+++ b/src/components/InlineEditScreen/InlineEditScreen.js
@@ -57,10 +57,10 @@ InlineEditScreen.propTypes = {
   show: PropTypes.bool,
   form: PropTypes.string.isRequired,
   flipId: PropTypes.string,
-  handleSubmit: PropTypes.func.isRequired,
   title: PropTypes.string,
+  onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  submit: PropTypes.func.isRequired,
+  submitForm: PropTypes.func.isRequired,
   children: PropTypes.node,
 };
 

--- a/src/components/NewVariableWindow/NewVariableWindow.js
+++ b/src/components/NewVariableWindow/NewVariableWindow.js
@@ -13,7 +13,6 @@ import { Section } from '@components/EditorLayout';
 import InlineEditScreen from '@components/InlineEditScreen';
 import withNewVariableHandler, { form } from './withNewVariableHandler';
 
-
 const isRequired = required();
 
 class NewVariableWindow extends Component {

--- a/src/components/enhancers/withCreateEdgeHandler.js
+++ b/src/components/enhancers/withCreateEdgeHandler.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
 import { withHandlers, compose } from 'recompose';
-import { actionCreators as codebookActions } from '../../ducks/modules/protocol/codebook';
+import { actionCreators as codebookActions } from '@modules/protocol/codebook';
+
+// TODO: withCreateEdgeType
 
 const mapDispatchToProps = {
   createEdge: codebookActions.createEdge,

--- a/src/components/enhancers/withCreateVariableHandler.js
+++ b/src/components/enhancers/withCreateVariableHandler.js
@@ -45,7 +45,6 @@ const createVariableHandler = {
   *   <div handler={() => handleCreateVarible(value, type)} />
   * )
   */
-
 const withCreateVariableHandler =
   compose(
     connect(null, mapDispatchToProps),

--- a/src/components/sections/CategoricalBinPrompts/PromptFields.js
+++ b/src/components/sections/CategoricalBinPrompts/PromptFields.js
@@ -5,7 +5,7 @@ import { getFieldId } from '@app/utils/issues';
 import { Text, Toggle } from '@codaco/ui/lib/components/Fields';
 import DetachedField from '@components/DetachedField';
 import { ValidatedField } from '@components/Form';
-import CreatableSelect from '@components/Form/Fields/CreatableSelect';
+import VariableSelect from '@components/Form/Fields/VariableSelect';
 import MultiSelect from '@components/Form/MultiSelect';
 import Options from '@components/Options';
 import { Section, Row } from '@components/EditorLayout';
@@ -25,17 +25,17 @@ const useToggle = (initialState) => {
 };
 
 const PromptFields = ({
-  variableOptions,
-  optionsForVariableDraft,
-  form,
   changeForm,
-  onDeleteVariable,
-  onCreateOtherVariable,
-  normalizeKeyDown,
   entity,
+  form,
+  normalizeKeyDown,
+  onCreateOtherVariable,
+  onDeleteVariable,
+  optionsForVariableDraft,
+  otherVariable,
   type,
   variable,
-  otherVariable,
+  variableOptions,
 }) => {
   const [otherVariableToggle, toggleOtherVariableToggle] = useToggle(!!otherVariable);
 
@@ -107,7 +107,9 @@ const PromptFields = ({
         <h3 id={getFieldId('variable')}>Categorical Variable</h3>
         <ValidatedField
           name="variable"
-          component={CreatableSelect}
+          component={VariableSelect}
+          type={type}
+          entity={entity}
           label=""
           options={categoricalVariableOptions}
           onCreateOption={handleNewVariable}
@@ -178,7 +180,9 @@ const PromptFields = ({
           />
           <ValidatedField
             name="otherVariable"
-            component={CreatableSelect}
+            component={VariableSelect}
+            entity={entity}
+            type={type}
             label="Variable to store response"
             options={otherVariableOptions}
             onCreateOption={onCreateOtherVariable}
@@ -239,9 +243,9 @@ const PromptFields = ({
 
 PromptFields.propTypes = {
   entity: PropTypes.string.isRequired,
+  otherVariable: PropTypes.string,
   type: PropTypes.string.isRequired,
   variable: PropTypes.string,
-  otherVariable: PropTypes.string,
   variableOptions: PropTypes.array,
 };
 

--- a/src/components/sections/CategoricalBinPrompts/__tests__/PromptFields.test.js
+++ b/src/components/sections/CategoricalBinPrompts/__tests__/PromptFields.test.js
@@ -19,10 +19,20 @@ const initialState = {
           person: {
             variables: {
               bazz: {
-                options: ['a', 'b', 'c', 'd'],
+                name: 'bazz',
+                options: [
+                  { value: 'a', label: 'a' },
+                  { value: 'b', label: 'b' },
+                  { value: 'c', label: 'c' },
+                  { value: 'd', label: 'd' },
+                ],
               },
               buzz: {
-                options: [1, 2],
+                name: 'buzz',
+                options: [
+                  { value: 1, label: '1' },
+                  { value: 2, label: '2' },
+                ],
               },
             },
           },
@@ -53,82 +63,104 @@ const getSubject = (node, store, { form }) =>
   ));
 
 // eslint-disable-next-line import/prefer-default-export
-export const testPromptFields = (PromptFieldsComponent) => {
+export const testPromptFields = (PromptFieldsComponent, name = '') => {
   let mockStore;
 
   beforeEach(() => {
     mockStore = getStore(initialState);
   });
 
-  describe('PromptFields', () => {
-    it('when variable is created, variable options are updated', () => {
-      const formProps = { initialValues: { variable: 'bazz', variableOptions: ['a', 'b', 'c', 'd'] } };
-      const additionalProps = { form: formProps };
+  // TODO This seems to test the wrong part of codebook
 
-      const subject = getSubject(
-        (
-          <PromptFieldsComponent
-            form={mockFormName}
-            entity="node"
-            type="person"
-            handleDeleteVariable={jest.fn()}
-          />
-        ),
-        mockStore,
-        additionalProps,
-      );
+  describe(name, () => {
+    describe('PromptFields', () => {
+      it('when variable is created, variable options are updated', () => {
+        const formProps = {
+          initialValues: {
+            variable: 'bazz',
+            variableOptions: [
+              { label: 'bazz', value: 'bazz' },
+              { label: 'buzz', value: 'buzz' },
+            ],
+          },
+        };
+        const additionalProps = { form: formProps };
 
-      expect(subject.find(Options).find(Item).length).toBe(4);
+        const subject = getSubject(
+          (
+            <PromptFieldsComponent
+              form={mockFormName}
+              entity="node"
+              type="person"
+              handleDeleteVariable={jest.fn()}
+              handleUpdate={jest.fn()}
+            />
+          ),
+          mockStore,
+          additionalProps,
+        );
 
-      mockStore.dispatch(codebookActions.createVariable(
-        'node',
-        'person',
-        {
-          name: 'fizz',
-          type: 'foo',
-          options: [1, 2, 3],
-        },
-      ));
+        expect(subject.find(Options).find(Item).length).toBe(2);
 
-      mockStore.dispatch(change(
-        mockFormName,
-        'variable',
-        '809895df-bbd7-4c76-ac58-e6ada2625f9b',
-      ));
+        mockStore.dispatch(codebookActions.createVariable(
+          'node',
+          'person',
+          {
+            name: 'fizz',
+            type: 'foo',
+            options: [1, 2, 3],
+          },
+        ));
 
-      subject.update();
+        mockStore.dispatch(change(
+          mockFormName,
+          'variable',
+          '809895df-bbd7-4c76-ac58-e6ada2625f9b',
+        ));
 
-      expect(subject.find(Options).find(Item).length).toBe(3);
-    });
+        subject.update();
 
-    it('when variable is changed, variable options are updated', () => {
-      const formProps = { initialValues: { variable: 'bazz', variableOptions: ['a', 'b', 'c', 'd'] } };
-      const additionalProps = { form: formProps };
+        expect(subject.find(Options).find(Item).length).toBe(3);
+      });
 
-      const subject = getSubject(
-        (
-          <PromptFieldsComponent
-            form={mockFormName}
-            entity="node"
-            type="person"
-            handleDeleteVariable={jest.fn()}
-          />
-        ),
-        mockStore,
-        additionalProps,
-      );
+      it('when variable is changed, variable options are updated', () => {
+        const formProps = {
+          initialValues: {
+            variable: 'bazz',
+            variableOptions: [
+              { label: 'bazz', value: 'bazz' },
+              { label: 'buzz', value: 'buzz' },
+            ],
+          },
+        };
+        const additionalProps = { form: formProps };
 
-      expect(subject.find(Options).find(Item).length).toBe(4);
+        const subject = getSubject(
+          (
+            <PromptFieldsComponent
+              form={mockFormName}
+              entity="node"
+              type="person"
+              handleDeleteVariable={jest.fn()}
+              handleUpdate={jest.fn()}
+            />
+          ),
+          mockStore,
+          additionalProps,
+        );
 
-      mockStore.dispatch(change(
-        mockFormName,
-        'variable',
-        'buzz',
-      ));
+        expect(subject.find(Options).find(Item).length).toBe(2);
 
-      subject.update();
+        mockStore.dispatch(change(
+          mockFormName,
+          'variable',
+          'buzz',
+        ));
 
-      expect(subject.find(Options).find(Item).length).toBe(2);
+        subject.update();
+
+        expect(subject.find(Options).find(Item).length).toBe(2);
+      });
     });
   });
 };

--- a/src/components/sections/Form/FieldFields.js
+++ b/src/components/sections/Form/FieldFields.js
@@ -6,7 +6,7 @@ import { isVariableTypeWithOptions, isVariableTypeWithParameters } from '@app/co
 import { getFieldId } from '@app/utils/issues';
 import ValidatedField from '@components/Form/ValidatedField';
 import Select from '@components/Form/Fields/Select';
-import CreatableSelect from '@components/Form/Fields/CreatableSelect';
+import VariableSelect from '@components/Form/Fields/VariableSelect';
 import Options from '@components/Options';
 import Parameters from '@components/Parameters';
 import Validations from '@components/Validations';
@@ -28,6 +28,8 @@ const PromptFields = ({
   handleChangeComponent,
   handleChangeVariable,
   handleDeleteVariable,
+  entity,
+  type,
 }) => (
   <Section>
     <Row contentId="guidance.section.form.field.name">
@@ -45,7 +47,9 @@ const PromptFields = ({
       }
       <ValidatedField
         name="variable"
-        component={CreatableSelect}
+        component={VariableSelect}
+        entity={entity}
+        type={type}
         options={variableOptions} // from variables
         onCreateOption={handleNewVariable} // reset later fields, create variable of no type?
         onChange={handleChangeVariable} // read/reset component options validation
@@ -159,6 +163,8 @@ PromptFields.propTypes = {
   handleNewVariable: PropTypes.func.isRequired,
   handleChangeVariable: PropTypes.func.isRequired,
   handleDeleteVariable: PropTypes.func.isRequired,
+  entity: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 PromptFields.defaultProps = {

--- a/src/components/sections/NarrativePresets/PresetFields.js
+++ b/src/components/sections/NarrativePresets/PresetFields.js
@@ -6,12 +6,10 @@ import { Field } from 'redux-form';
 import Text from '@codaco/ui/lib/components/Fields/Text';
 import CheckboxGroup from '@codaco/ui/lib/components/Fields/CheckboxGroup';
 import Select from '@components/Form/Fields/Select';
-import CreatableSelect from '@components/Form/Fields/CreatableSelect';
+import VariableSelect from '@components/Form/Fields/VariableSelect';
 import ValidatedField from '@components/Form/ValidatedField';
 import { getFieldId } from '@app/utils/issues';
-import withNewVariableWindowHandlers, {
-  propTypes as newVariableWindowPropTypes,
-} from '@components/enhancers/withNewVariableWindowHandlers';
+import withNewVariableWindowHandlers from '@components/enhancers/withNewVariableWindowHandlers';
 import { normalizeKeyDown } from '@components/enhancers/withCreateVariableHandler';
 import { Section, Row } from '@components/EditorLayout';
 import withPresetProps from './withPresetProps';
@@ -23,6 +21,8 @@ const PresetFields = ({
   highlightVariablesForSubject,
   handleCreateLayoutVariable,
   handleDeleteVariable,
+  entity,
+  type,
 }) => (
   <Section>
     <Row>
@@ -38,7 +38,9 @@ const PresetFields = ({
     <Row>
       <ValidatedField
         name="layoutVariable"
-        component={CreatableSelect}
+        component={VariableSelect}
+        entity={entity}
+        type={type}
         label="Layout variable"
         placeholder="&mdash; Select a layout variable &mdash;"
         validation={{ required: true }}
@@ -87,7 +89,8 @@ PresetFields.propTypes = {
   highlightVariablesForSubject: PropTypes.array,
   handleCreateLayoutVariable: PropTypes.func.isRequired,
   handleDeleteVariable: PropTypes.func.isRequired,
-  ...newVariableWindowPropTypes,
+  entity: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 PresetFields.defaultProps = {

--- a/src/components/sections/OrdinalBinPrompts/PromptFields.js
+++ b/src/components/sections/OrdinalBinPrompts/PromptFields.js
@@ -4,7 +4,7 @@ import { compose } from 'recompose';
 import Text from '@codaco/ui/lib/components/Fields/Text';
 import { getFieldId } from '@app/utils/issues';
 import { ValidatedField } from '@components/Form';
-import CreatableSelect from '@components/Form/Fields/CreatableSelect';
+import VariableSelect from '@components/Form/Fields/VariableSelect';
 import ColorPicker from '@components/Form/Fields/ColorPicker';
 import MultiSelect from '@components/Form/MultiSelect';
 import { Section, Row } from '@components/EditorLayout';
@@ -16,14 +16,14 @@ import withVariableOptions from '@components/sections/CategoricalBinPrompts/with
 import withVariableHandlers from '@components/sections/CategoricalBinPrompts/withVariableHandlers';
 
 const PromptFields = ({
-  variableOptions,
+  changeForm,
+  entity,
+  form,
   normalizeKeyDown,
   onDeleteVariable,
-  entity,
-  changeForm,
-  form,
   type,
   variable,
+  variableOptions,
 }) => {
   const newVariableWindowInitialProps = {
     entity,
@@ -76,7 +76,9 @@ const PromptFields = ({
         </p>
         <ValidatedField
           name="variable"
-          component={CreatableSelect}
+          component={VariableSelect}
+          entity={entity}
+          type={type}
           label=""
           options={ordinalVariableOptions}
           onCreateOption={handleNewVariable}
@@ -160,7 +162,6 @@ const PromptFields = ({
           options={getSortOrderOptionGetter(variableOptions)}
         />
       </Row>
-
 
       <NewVariableWindow {...newVariableWindowProps} />
     </Section>

--- a/src/components/sections/OrdinalBinPrompts/__tests__/PromptFields.test.js
+++ b/src/components/sections/OrdinalBinPrompts/__tests__/PromptFields.test.js
@@ -2,4 +2,6 @@
 import { testPromptFields } from '../../CategoricalBinPrompts/__tests__/PromptFields.test';
 import PromptFields from '../PromptFields';
 
+// jest.mock('@components/NewVariableWindow');
+
 testPromptFields(PromptFields);

--- a/src/components/sections/QuickAdd/QuickAdd.js
+++ b/src/components/sections/QuickAdd/QuickAdd.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 import { Section } from '@components/EditorLayout';
 import VariableSelect from '../../Form/Fields/VariableSelect';
-// import CreatableSelect from '../../Form/Fields/CreatableSelect';
 import ValidatedField from '../../Form/ValidatedField';
 import withOptions from './withOptions';
 import withCreateVariableHandler from '../../enhancers/withCreateVariableHandler';

--- a/src/components/sections/QuickAdd/QuickAdd.js
+++ b/src/components/sections/QuickAdd/QuickAdd.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 import { Section } from '@components/EditorLayout';
-import CreatableSelect from '../../Form/Fields/CreatableSelect';
+import VariableSelect from '../../Form/Fields/VariableSelect';
+// import CreatableSelect from '../../Form/Fields/CreatableSelect';
 import ValidatedField from '../../Form/ValidatedField';
 import withOptions from './withOptions';
 import withCreateVariableHandler from '../../enhancers/withCreateVariableHandler';
@@ -15,10 +16,12 @@ import Tip from '../../Tip';
 
 const QuickAdd = ({
   disabled,
-  options,
+  entity,
   handleCreateVariable,
   handleDeleteVariable,
   normalizeKeyDown,
+  options,
+  type,
 }) => (
   <Section disabled={disabled} group contentId="guidance.editor.quickAdd">
     <h3 id="issue-form">Quick Add Variable</h3>
@@ -37,13 +40,15 @@ const QuickAdd = ({
     <div className="stage-editor-section-form">
       <ValidatedField
         name="quickAdd"
-        component={CreatableSelect}
+        component={VariableSelect}
         placeholder="Select an existing variable, or type to create a new one..."
         options={options}
         onCreateOption={value => handleCreateVariable(value, 'text')}
         onDeleteOption={handleDeleteVariable}
         onKeyDown={normalizeKeyDown}
         validation={{ required: true }}
+        type={type}
+        entity={entity}
         formatCreateLabel={inputValue => (
           <span>Click here to create a new variable named &quot;{inputValue}&quot;.</span>
         )}
@@ -54,10 +59,12 @@ const QuickAdd = ({
 
 QuickAdd.propTypes = {
   disabled: PropTypes.bool,
-  options: PropTypes.array,
+  entity: PropTypes.string.isRequired,
   handleCreateVariable: PropTypes.func.isRequired,
   handleDeleteVariable: PropTypes.func.isRequired,
   normalizeKeyDown: PropTypes.func.isRequired,
+  options: PropTypes.array,
+  type: PropTypes.string.isRequired,
 };
 
 QuickAdd.defaultProps = {

--- a/src/components/sections/SociogramPrompts/PromptFieldsEdges.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsEdges.js
@@ -4,13 +4,13 @@ import { Field } from 'redux-form';
 import { compose } from 'recompose';
 import * as Fields from '@codaco/ui/lib/components/Fields';
 import { Section, Row } from '@components/EditorLayout';
-import * as ArchitectFields from '../../Form/Fields';
-import DetachedField from '../../DetachedField';
+import CreatableSelect from '@components/Form/Fields/CreatableSelect';
+import DetachedField from '@components/DetachedField';
+import withCreateEdgeHandlers from '@components/enhancers/withCreateEdgeHandler';
+import { ValidatedField } from '@components/Form';
+import Tip from '@components/Tip';
 import withEdgesOptions from './withEdgesOptions';
 import withEdgeHighlightChangeHandler from './withEdgeHighlightChangeHandler';
-import withCreateEdgeHandlers from '../../enhancers/withCreateEdgeHandler';
-import { ValidatedField } from '../../Form';
-import Tip from '../../Tip';
 
 const EdgeFields = ({
   edgesForSubject,
@@ -62,7 +62,7 @@ const EdgeFields = ({
         { canCreateEdge &&
           <ValidatedField
             name="edges.create"
-            component={ArchitectFields.CreatableSelect}
+            component={CreatableSelect}
             options={edgesForSubject}
             onCreateOption={handleCreateEdge}
             onChange={handleChangeCreateEdge}

--- a/src/components/sections/SociogramPrompts/PromptFieldsHighlight.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsHighlight.js
@@ -4,22 +4,24 @@ import { Field } from 'redux-form';
 import { compose } from 'recompose';
 import * as Fields from '@codaco/ui/lib/components/Fields';
 import { Section, Row } from '@components/EditorLayout';
-import * as ArchitectFields from '../../Form/Fields';
-import ValidatedField from '../../Form/ValidatedField';
-import withCreateVariableHandlers from '../../enhancers/withCreateVariableHandler';
+import VariableSelect from '@components/Form/Fields/VariableSelect';
+import ValidatedField from '@components/Form/ValidatedField';
+import withCreateVariableHandlers from '@components/enhancers/withCreateVariableHandler';
+import Tip from '@components/Tip';
 import withHighlightOptions from './withHighlightOptions';
 import withEdgeHighlightChangeHandler from './withEdgeHighlightChangeHandler';
-import Tip from '../../Tip';
 
 const HighlightFields = ({
   allowHighlighting,
-  highlightVariablesForSubject,
-  handleEdgeHighlightChange,
+  canCreateEdge,
+  entity,
   handleCreateVariable,
   handleDeleteVariable,
+  handleEdgeHighlightChange,
+  highlightVariablesForSubject,
   normalizeKeyDown,
-  canCreateEdge,
   setCanCreateEdge,
+  type,
 }) => {
   const handleChangeAllowHighlighting = (value) => {
     handleEdgeHighlightChange();
@@ -52,7 +54,9 @@ const HighlightFields = ({
         { allowHighlighting &&
           <ValidatedField
             name="highlight.variable"
-            component={ArchitectFields.CreatableSelect}
+            component={VariableSelect}
+            entity={entity}
+            type={type}
             label="Which boolean variable should be toggled?"
             onCreateOption={value => handleCreateVariable(value, 'boolean')}
             onDeleteOption={value => handleDeleteVariable(value)}
@@ -73,14 +77,16 @@ const HighlightFields = ({
 };
 
 HighlightFields.propTypes = {
-  highlightVariablesForSubject: PropTypes.array.isRequired,
-  handleEdgeHighlightChange: PropTypes.func.isRequired,
+  allowHighlighting: PropTypes.bool,
+  canCreateEdge: PropTypes.bool.isRequired,
+  entity: PropTypes.string.isRequired,
   handleCreateVariable: PropTypes.func.isRequired,
   handleDeleteVariable: PropTypes.func.isRequired,
+  handleEdgeHighlightChange: PropTypes.func.isRequired,
+  highlightVariablesForSubject: PropTypes.array.isRequired,
   normalizeKeyDown: PropTypes.func.isRequired,
-  canCreateEdge: PropTypes.bool.isRequired,
   setCanCreateEdge: PropTypes.func.isRequired,
-  allowHighlighting: PropTypes.bool,
+  type: PropTypes.string.isRequired,
 };
 
 HighlightFields.defaultProps = {

--- a/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
+++ b/src/components/sections/SociogramPrompts/PromptFieldsLayout.js
@@ -4,7 +4,8 @@ import { Field } from 'redux-form';
 import { compose } from 'recompose';
 import { getFieldId } from '@app/utils/issues';
 import { ValidatedField } from '@components/Form';
-import * as ArchitectFields from '@components/Form/Fields';
+import VariableSelect from '@components/Form/Fields/VariableSelect';
+import OrderBy from '@components/Form/Fields/OrderBy';
 import Tip from '@components/Tip';
 import withCreateVariableHandlers from '@components/enhancers/withCreateVariableHandler';
 import { Section, Row } from '@components/EditorLayout';
@@ -12,12 +13,14 @@ import withLayoutOptions from './withLayoutOptions';
 import withCanCreateEdgesState from './withCanCreateEdgesState';
 
 const PromptFields = ({
+  allowPositioning,
+  entity,
   handleCreateVariable,
   handleDeleteVariable,
-  normalizeKeyDown,
-  variablesForSubject,
   layoutVariablesForSubject,
-  allowPositioning,
+  normalizeKeyDown,
+  type,
+  variablesForSubject,
 }) => (
   <Section contentId="guidance.editor.sociogram_prompt.layout" group>
     <Row>
@@ -38,7 +41,9 @@ const PromptFields = ({
 
       <ValidatedField
         name="layout.layoutVariable"
-        component={ArchitectFields.CreatableSelect}
+        type={type}
+        entity={entity}
+        component={VariableSelect}
         placeholder="&mdash; Select a new layout variable, or type to create a new one &mdash;"
         validation={{ required: true }}
         options={layoutVariablesForSubject}
@@ -76,7 +81,7 @@ const PromptFields = ({
         </p>
         <Field
           name="sortOrder"
-          component={ArchitectFields.OrderBy}
+          component={OrderBy}
           variables={variablesForSubject}
         />
       </Row>
@@ -85,12 +90,14 @@ const PromptFields = ({
 );
 
 PromptFields.propTypes = {
+  allowPositioning: PropTypes.bool,
+  entity: PropTypes.string.isRequired,
   handleCreateVariable: PropTypes.func.isRequired,
   handleDeleteVariable: PropTypes.func.isRequired,
-  normalizeKeyDown: PropTypes.func.isRequired,
-  variablesForSubject: PropTypes.object.isRequired,
   layoutVariablesForSubject: PropTypes.array.isRequired,
-  allowPositioning: PropTypes.bool,
+  normalizeKeyDown: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
+  variablesForSubject: PropTypes.object.isRequired,
 };
 
 PromptFields.defaultProps = {

--- a/src/components/sections/fields/EdgeTypeFields/withCreateEdgeType.js
+++ b/src/components/sections/fields/EdgeTypeFields/withCreateEdgeType.js
@@ -4,6 +4,8 @@ import { withHandlers, compose } from 'recompose';
 import { actionCreators as screenActions } from '@modules/ui/screens';
 import { makeScreenMessageListener } from '@selectors/ui';
 
+// TODO: withCreateEdgeHandler
+
 const mapStateToProps = () => {
   const screenMessageListener = makeScreenMessageListener('type');
 

--- a/src/styles/components/form/fields/_select.scss
+++ b/src/styles/components/form/fields/_select.scss
@@ -56,7 +56,8 @@ img.form-fields-select { // sass-lint:disable-line no-qualifying-elements, force
     }
 
     &-add,
-    &-delete {
+    &-delete,
+    &-warning {
       display: inline-flex;
       align-items: center;
       flex: 0 0 1rem;
@@ -82,10 +83,24 @@ img.form-fields-select { // sass-lint:disable-line no-qualifying-elements, force
         height: 1rem;
       }
     }
+
+    &-warning {
+      .icon {
+        height: 2rem;
+        width: 2.5rem;
+        line-height: 1rem;
+        padding: .3rem;
+        margin-right: unit(1);
+      }
+    }
+
+    &--warning {
+      background: var(--warning) !important;
+      color: var(--color-white) !important;
+    }
   }
 
   &__option {
-
     width: 100%;
     font-size: var(--base-font-size);
 
@@ -101,7 +116,6 @@ img.form-fields-select { // sass-lint:disable-line no-qualifying-elements, force
     &--is-selected {
       background-color: var(--primary);
     }
-
   }
 
   &__full {

--- a/src/styles/components/form/fields/_select.scss
+++ b/src/styles/components/form/fields/_select.scss
@@ -39,6 +39,24 @@ img.form-fields-select { // sass-lint:disable-line no-qualifying-elements, force
     padding: 0;
   }
 
+  &__option {
+    width: 100%;
+    font-size: var(--base-font-size);
+
+    &:active {
+      background-color: var(--color-sea-green--dark);
+      color: var(--text-light);
+    }
+
+    &--is-focused {
+      background-color: var(--color-platinum);
+    }
+
+    &--is-selected {
+      background-color: var(--primary);
+    }
+  }
+
   &__item {
     padding: 0 1rem;
     display: flex;
@@ -95,26 +113,8 @@ img.form-fields-select { // sass-lint:disable-line no-qualifying-elements, force
     }
 
     &--warning {
-      background: var(--warning) !important;
-      color: var(--color-white) !important;
-    }
-  }
-
-  &__option {
-    width: 100%;
-    font-size: var(--base-font-size);
-
-    &:active {
-      background-color: var(--color-sea-green--dark);
-      color: var(--text-light);
-    }
-
-    &--is-focused {
-      background-color: var(--color-platinum);
-    }
-
-    &--is-selected {
-      background-color: var(--primary);
+      background: var(--warning);
+      color: var(--color-white);
     }
   }
 


### PR DESCRIPTION
When a variable is created inline the variable name was only compared against those of the same type, but we require variable names to be distinct accross types.

This adds functionality to supply an additional 'reserved' list to CreatableSelect, and a new component VariableSelect which automatically populates this list based on the entity type.

Some of the improvements seen here could be taken further, but due to the impending release I've left it here.

Possible improvements:
- Do variableOptions and reserved lists both need to exist for the validation check?
- Could we also have specialised components for other CreatbleSelects, e.g. edge type selector?
- Since we pass `entity` and `type` to the variable select it's no longer necessary to pass the createVariable handlers to the parent component, it could be completely handled by VariableSelect to simplify PromptFields

Resolves: #623